### PR TITLE
Implement mlflow metrics logging in utility class, use accross manual scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # ignore local data
 data/
+
+# ignore mlflow local dumps
+mlruns/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ lightgbm==3.2.1
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-mock==3.6.1
-mlflow==0.19.0
+mlflow==1.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lightgbm==3.2.1
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-mock==3.6.1
+mlflow==0.19.0

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -86,12 +86,10 @@ class LogTimeBlock(object):
 
     Example
     -------
-    >>> job_profile = {}
-    >>> with LogTimeBlock("my_perf_metric_name", methods=['print']):
+    >>> with LogTimeBlock("my_perf_metric_name"):
             print("(((sleeping for 1 second)))")
             time.sleep(1)
     --- time elapsted my_perf_metric_name : 1.0 s
-    >>> job_profile
     { 'my_perf_metric_name': 1.0 }
     """
 
@@ -106,13 +104,10 @@ class LogTimeBlock(object):
 
         Keyword Arguments
         -----------------
-        print: {bool}
-            prints out time with print()
         tags: {dict}
             add properties to metrics for logging as log_row()
         """
         # kwargs
-        self.methods = kwargs.get('methods', ['print'])
         self.tags = kwargs.get('tags', None)
 
         # internal variables
@@ -129,15 +124,8 @@ class LogTimeBlock(object):
         Note: arguments are by design for with statements. """
         run_time = time.time() - self.start_time # stops "timer"
 
-        for method in self.methods:
-            if method == "print":
-                # just prints nicely
-                print(f"--- time elapsed: {self.name} = {run_time:2f} s" + (f" [tags: {self.tags}]" if self.tags else ""))
-                MetricsLogger().log_metric(self.name, run_time)
-            else:
-                # Place holder for mlflow
-                raise NotImplementedError("Nothing else exists at this point")
-
+        print(f"--- time elapsed: {self.name} = {run_time:2f} s" + (f" [tags: {self.tags}]" if self.tags else ""))
+        MetricsLogger().log_metric(self.name, run_time)
 
 
 ####################

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -51,8 +51,8 @@ class MetricsLogger():
     def log_metric(self, key, value):
         print(f"mlflow[session={self._session_name}].log_metric({key},{value})")
         # NOTE: there's a limit to the name of a metric
-        if len(key) > 45:
-            key = key[:45]
+        if len(key) > 50:
+            key = key[:50]
         mlflow.log_metric(key, value)
 
     def set_properties(self, **kwargs):

--- a/src/scripts/lightgbm_python/score.py
+++ b/src/scripts/lightgbm_python/score.py
@@ -18,7 +18,7 @@ if COMMON_ROOT not in sys.path:
     sys.path.append(str(COMMON_ROOT))
 
 # before doing local import
-from common.metrics import LogTimeBlock
+from common.metrics import MetricsLogger
 from common.io import input_file_path
 
 
@@ -61,18 +61,35 @@ def run(args, other_args=[]):
         os.makedirs(args.output, exist_ok=True)
         args.output = os.path.join(args.output, "predictions.txt")
 
+    # initializes reporting of metrics
+    metrics_logger = MetricsLogger("lightgbm_python.score")
+
+    # add some properties to the session
+    metrics_logger.set_properties(
+        framework = 'lightgbm_python',
+        task = 'score',
+        lightgbm_version = lightgbm.__version__
+    )
+
     print(f"Loading model from {args.model}")
     booster = lightgbm.Booster(model_file=args.model)
 
-    metric_tags = {'framework':'lightgbm_python','task':'score','lightgbm_version':lightgbm.__version__}
-
     print(f"Loading data for inferencing")
-    with LogTimeBlock("data_loading", methods=['print'], tags=metric_tags):
+    with metrics_logger.log_time_block("data_loading"):
         raw_data = numpy.loadtxt(args.data, delimiter=",")
 
+    # capture data shape as property
+    metrics_logger.set_properties(
+        inference_data_length = raw_data.shape[0],
+        inference_data_width = raw_data.shape[1]
+    )
+
     print(f"Running .predict()")
-    with LogTimeBlock("inferencing", methods=['print'], tags=metric_tags):
+    with metrics_logger.log_time_block("inferencing"):
         booster.predict(data=raw_data)
+
+    # optional: close logging session
+    metrics_logger.close()
 
 
 def main(cli_args=None):

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -78,6 +78,6 @@ def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
     metrics_logger = MetricsLogger()
 
     with metrics_logger.log_time_block("foo_metric"):
-        time.sleep(1)
+        time.sleep(0.01)
 
     mlflow_log_metric_mock.assert_called_once()

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -25,6 +25,25 @@ def test_metrics_logger_log_metric(mlflow_log_metric_mock):
     )
 
 
+@patch('mlflow.log_metric')
+def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
+    """ Tests MetricsLogger().log_metric() """
+    metrics_logger = MetricsLogger()
+
+    metric_key = "x" * 250
+    assert len(metric_key), 250
+
+    short_metric_key = "x" * 50
+    assert len(short_metric_key), 50
+
+    metrics_logger.log_metric(
+        metric_key, "bar"
+    )
+    mlflow_log_metric_mock.assert_called_with(
+        short_metric_key, "bar"
+    )
+
+
 @patch('mlflow.set_tags')
 def test_metrics_logger_set_properties(mlflow_set_tags_mock):
     """ Tests MetricsLogger().set_properties() """

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -38,6 +38,7 @@ def test_metrics_logger_set_properties(mlflow_set_tags_mock):
         { 'key1' : "foo", 'key2' : 0.45 }
     )
 
+
 @patch('mlflow.log_params')
 def test_metrics_logger_set_properties(mlflow_log_params_mock):
     """ Tests MetricsLogger().log_parameters() """
@@ -50,6 +51,7 @@ def test_metrics_logger_set_properties(mlflow_log_params_mock):
     mlflow_log_params_mock.assert_called_with(
         { 'key1' : "foo", 'key2' : 0.45 }
     )
+
 
 @patch('mlflow.log_metric')
 def test_metrics_logger_log_time_block(mlflow_log_metric_mock):

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -1,0 +1,62 @@
+"""Tests src/common/metrics.py"""
+import os
+import pytest
+from unittest.mock import Mock, patch
+import time
+
+from common.metrics import MetricsLogger
+
+@patch('mlflow.start_run')
+def test_unique_mlflow_initialization(mlflow_start_run_mock):
+    """ Tests MetricsLogger() unique initialization of mlflow"""
+    metrics_logger = MetricsLogger()
+    metrics_logger_2 = MetricsLogger()
+    mlflow_start_run_mock.assert_called_once()
+
+
+@patch('mlflow.log_metric')
+def test_metrics_logger_log_metric(mlflow_log_metric_mock):
+    """ Tests MetricsLogger().log_metric() """
+    metrics_logger = MetricsLogger()
+
+    metrics_logger.log_metric("foo", "bar")
+    mlflow_log_metric_mock.assert_called_with(
+        "foo", "bar"
+    )
+
+
+@patch('mlflow.set_tags')
+def test_metrics_logger_set_properties(mlflow_set_tags_mock):
+    """ Tests MetricsLogger().set_properties() """
+    metrics_logger = MetricsLogger()
+
+    metrics_logger.set_properties(
+        key1 = "foo",
+        key2 = 0.45
+    )
+    mlflow_set_tags_mock.assert_called_with(
+        { 'key1' : "foo", 'key2' : 0.45 }
+    )
+
+@patch('mlflow.log_params')
+def test_metrics_logger_set_properties(mlflow_log_params_mock):
+    """ Tests MetricsLogger().log_parameters() """
+    metrics_logger = MetricsLogger()
+
+    metrics_logger.log_parameters(
+        key1 = "foo",
+        key2 = 0.45
+    )
+    mlflow_log_params_mock.assert_called_with(
+        { 'key1' : "foo", 'key2' : 0.45 }
+    )
+
+@patch('mlflow.log_metric')
+def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
+    """ Tests MetricsLogger().log_time_block() """
+    metrics_logger = MetricsLogger()
+
+    with metrics_logger.log_time_block("foo_metric"):
+        time.sleep(1)
+
+    mlflow_log_metric_mock.assert_called_once()


### PR DESCRIPTION
This PR implements an mlflow metrics logger as a utility class. This class is a singleton to ensure mlflow initialization happens only once. It provides methods for user scripts to log metrics without taking care of mlflow backend.

This class is then used accross existing manual scripts.