### PR TITLE
allow for libsvm format in score python

### DIFF
--- a/src/scripts/lightgbm_cli/score.py
+++ b/src/scripts/lightgbm_cli/score.py
@@ -71,7 +71,8 @@ def run(args, other_args=[]):
         args.lightgbm_exec,
         "task=prediction",
         f"data={args.data}",
-        f"input_model={args.model}"
+        f"input_model={args.model}",
+        "verbosity=2"
     ]
     if args.output:
         lightgbm_cli_command.append(f"output_result={args.output}")

--- a/src/scripts/lightgbm_python/score.py
+++ b/src/scripts/lightgbm_python/score.py
@@ -76,17 +76,19 @@ def run(args, other_args=[]):
 
     print(f"Loading data for inferencing")
     with metrics_logger.log_time_block("data_loading"):
-        raw_data = numpy.loadtxt(args.data, delimiter=",")
+        # NOTE: this is bad, but allows for libsvm format (not just numpy)
+        inference_data = lightgbm.Dataset(args.data, free_raw_data=False).construct()
+        inference_raw_data = inference_data.get_data()
 
     # capture data shape as property
     metrics_logger.set_properties(
-        inference_data_length = raw_data.shape[0],
-        inference_data_width = raw_data.shape[1]
+        inference_data_length = inference_data.num_data(),
+        inference_data_width = inference_data.num_feature()
     )
 
     print(f"Running .predict()")
     with metrics_logger.log_time_block("inferencing"):
-        booster.predict(data=raw_data)
+        booster.predict(data=inference_raw_data, predict_disable_shape_check=True)
 
     # optional: close logging session
     metrics_logger.close()

--- a/src/scripts/lightgbm_python/score.py
+++ b/src/scripts/lightgbm_python/score.py
@@ -9,6 +9,7 @@ import sys
 import argparse
 import lightgbm
 import numpy
+from distutils.util import strtobool
 
 # let's add the right PYTHONPATH for common module
 COMMON_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -45,6 +46,10 @@ def get_arg_parser(parser=None):
         required=False, type=input_file_path, help="Exported model location (file path)")
     group_i.add_argument("--output",
         required=False, default=None, type=str, help="Inferencing output location (file path)")
+    
+    group_params = parser.add_argument_group("Scoring parameters")
+    group_params.add_argument("--predict_disable_shape_check",
+        required=False, default=False, type=strtobool, help="See LightGBM documentation")
     
     return parser
 
@@ -88,7 +93,7 @@ def run(args, other_args=[]):
 
     print(f"Running .predict()")
     with metrics_logger.log_time_block("inferencing"):
-        booster.predict(data=inference_raw_data, predict_disable_shape_check=True)
+        booster.predict(data=inference_raw_data, predict_disable_shape_check=bool(args.predict_disable_shape_check))
 
     # optional: close logging session
     metrics_logger.close()


### PR DESCRIPTION
Instead of using numpy to load inputs, use lightgbm Dataset to construct the raw_data before calling predict.

this allows support of the file formats supported by lightgbm, ex libsvm, not just plain csv.