### PR TITLE
Implement reporting of system information in MetricsLogger

### DIFF
--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -8,7 +8,7 @@ import os
 import time
 from functools import wraps
 import mlflow
-
+import platform
 
 class MetricsLogger():
     """
@@ -59,6 +59,15 @@ class MetricsLogger():
         """ Set properties/tags for the session """
         print(f"mlflow[session={self._session_name}].set_tags({kwargs})")
         mlflow.set_tags(kwargs)
+
+    def set_platform_properties(self):
+        """ Capture platform sysinfo and record as properties """
+        self.set_properties(
+            machine=platform.machine(),
+            processor=platform.processor(),
+            system=platform.system(),
+            system_version=platform.version()
+        )
 
     def log_parameters(self, **kwargs):
         """ Set parameters for the session """

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -66,7 +66,8 @@ class MetricsLogger():
             machine=platform.machine(),
             processor=platform.processor(),
             system=platform.system(),
-            system_version=platform.version()
+            system_version=platform.version(),
+            cpu_count=os.cpu_count()
         )
 
     def log_parameters(self, **kwargs):

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from unittest.mock import Mock, patch
 import time
+import platform
 
 from common.metrics import MetricsLogger
 
@@ -55,6 +56,24 @@ def test_metrics_logger_set_properties(mlflow_set_tags_mock):
     )
     mlflow_set_tags_mock.assert_called_with(
         { 'key1' : "foo", 'key2' : 0.45 }
+    )
+
+
+@patch('mlflow.set_tags')
+def test_metrics_logger_set_platform_properties(mlflow_set_tags_mock):
+    """ Tests MetricsLogger().set_properties() """
+    metrics_logger = MetricsLogger()
+
+    platform_properties = {
+        "machine":platform.machine(),
+        "processor":platform.processor(),
+        "system":platform.system(),
+        "system_version":platform.version()
+    }
+    metrics_logger.set_platform_properties()
+    
+    mlflow_set_tags_mock.assert_called_with(
+        platform_properties
     )
 
 

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -68,10 +68,11 @@ def test_metrics_logger_set_platform_properties(mlflow_set_tags_mock):
         "machine":platform.machine(),
         "processor":platform.processor(),
         "system":platform.system(),
-        "system_version":platform.version()
+        "system_version":platform.version(),
+        "cpu_count":os.cpu_count()
     }
     metrics_logger.set_platform_properties()
-    
+
     mlflow_set_tags_mock.assert_called_with(
         platform_properties
     )


### PR DESCRIPTION
Based on a comment in the PR #9 this implements the function to automatically record some of the properties on the platform/system.