### PR TITLE
Implement method to record properties based on json string

### DIFF
--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -8,7 +8,7 @@ import os
 import time
 from functools import wraps
 import mlflow
-
+import json
 
 class MetricsLogger():
     """
@@ -59,6 +59,25 @@ class MetricsLogger():
         """ Set properties/tags for the session """
         print(f"mlflow[session={self._session_name}].set_tags({kwargs})")
         mlflow.set_tags(kwargs)
+
+    def set_properties_from_json(self, json_string):
+        """ Set properties/tags for the session from a json_string """
+        try:
+            json_dict = json.loads(json_string)
+        except:
+            raise Exception(f"During parsing of JSON properties '{json_string}', an exception occured: {traceback.format_exc()}")
+
+        if not isinstance(json_dict, dict):
+            raise Exception(f"Provided JSON properties should be a dict, instead it was {str(type(json_dict))}: {json_string}")
+        
+        properties_dict = dict(
+            [
+                (k, str(v)) # transform whatever as a string
+                for k,v in json_dict.items()
+            ]
+        )
+        self.set_properties(**properties_dict)
+
 
     def log_parameters(self, **kwargs):
         """ Set parameters for the session """

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -58,6 +58,31 @@ def test_metrics_logger_set_properties(mlflow_set_tags_mock):
     )
 
 
+@patch('mlflow.set_tags')
+def test_metrics_logger_set_properties_from_json(mlflow_set_tags_mock):
+    """ Tests MetricsLogger().set_properties_from_json() """
+    metrics_logger = MetricsLogger()
+
+    metrics_logger.set_properties_from_json(
+        "{ \"key1\" : \"foo\", \"key2\" : 0.45 }"
+    )
+    mlflow_set_tags_mock.assert_called_with(
+        { 'key1' : "foo", 'key2' : '0.45' }
+    )
+
+    with pytest.raises(Exception) as e_raised:
+        # failing json parsing
+        metrics_logger.set_properties_from_json(
+            "{ 'foo': NOTHING }"
+        )
+
+    with pytest.raises(Exception) as e_raised:
+        # failing if dict is not provided
+        metrics_logger.set_properties_from_json(
+            "[\"bla\", \"foo\"]"
+        )
+
+
 @patch('mlflow.log_params')
 def test_metrics_logger_set_properties(mlflow_log_params_mock):
     """ Tests MetricsLogger().log_parameters() """


### PR DESCRIPTION
To allow users to pass custom properties as command line arguments, this method parses a json string, tests the object minimally, then records keys as properties.