### PR TITLE
align treelite to sample and add unit tests

### DIFF
--- a/src/scripts/treelite_python/score.py
+++ b/src/scripts/treelite_python/score.py
@@ -2,25 +2,26 @@
 # Licensed under the MIT license.
 
 """
-LightGBM/Python inferencing script
+TreeLite/Python inferencing script
 """
 import os
 import sys
 import argparse
-import lightgbm
+import logging
 import numpy
 from distutils.util import strtobool
 import pandas as pd
 import treelite, treelite_runtime
 
-# let's add the right PYTHONPATH for common module
-COMMON_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+# Add the right path to PYTHONPATH
+# so that you can import from common.*
+COMMON_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 if COMMON_ROOT not in sys.path:
     print(f"Adding {COMMON_ROOT} to PYTHONPATH")
     sys.path.append(str(COMMON_ROOT))
 
-# before doing local import
+# useful imports from common
 from common.metrics import MetricsLogger
 from common.io import input_file_path
 
@@ -37,80 +38,137 @@ def get_arg_parser(parser=None):
     Notes:
         if parser is None, creates a new parser instance
     """
-    # add arguments that are specific to the module
+    # add arguments that are specific to the script
     if parser is None:
         parser = argparse.ArgumentParser(__doc__)
 
     group_i = parser.add_argument_group("Input Data")
     group_i.add_argument("--data",
         required=True, type=input_file_path, help="Inferencing data location (file path)")
-    group_i.add_argument("--nthreads",
-        required=False, default = 1, type=int, help="number of threads")
     group_i.add_argument("--model",
         required=False, type=input_file_path, help="Exported model location (file path)")
     group_i.add_argument("--output",
         required=False, default=None, type=str, help="Inferencing output location (file path)")
     
+    group_treelite = parser.add_argument_group("Treelite parameters")
+    group_treelite.add_argument("--model_format",
+        required=False, default="lightgbm", type=str, help="format of the input --model")
+    group_treelite.add_argument("--toolchain",
+        required=False, default="gcc", type=str, help="toolchain for compiling model")
+
     group_params = parser.add_argument_group("Scoring parameters")
-    group_params.add_argument("--predict_disable_shape_check",
-        required=False, default=False, type=strtobool, help="See LightGBM documentation")
+    group_params.add_argument("--nthreads",
+        required=False, default=1, type=int, help="number of threads")
     
+    group_general = parser.add_argument_group("General parameters")
+    group_general.add_argument(
+        "--verbose",
+        required=False,
+        default=False,
+        type=strtobool,  # use this for bool args, do not use action_store=True
+        help="set True to show DEBUG logs",
+    )
+    group_general.add_argument(
+        "--custom_properties",
+        required=False,
+        default=None,
+        type=str,
+        help="provide custom properties as json dict",
+    )
+
     return parser
 
 
-def run(args, other_args=[]):
+def run(args, unknown_args=[]):
     """Run script with arguments (the core of the component)
 
     Args:
         args (argparse.namespace): command line arguments provided to script
         unknown_args (list[str]): list of arguments not known
     """
-    # create sub dir and output file
-    if args.output:
-        os.makedirs(args.output, exist_ok=True)
-        args.output = os.path.join(args.output, "predictions.txt")
+    # get logger for general outputs
+    logger = logging.getLogger()
 
-    # initializes reporting of metrics
+    # get Metrics logger for benchmark metrics
+    # below: initialize reporting of metrics with a custom session name
     metrics_logger = MetricsLogger("treelite.score")
 
     # add some properties to the session
     metrics_logger.set_properties(
         framework = 'treelite_python',
         task = 'score',
-        lightgbm_version = lightgbm.__version__
+        lightgbm_version = treelite.__version__
     )
 
+    # if provided some custom_properties by the outside orchestrator
+    if args.custom_properties:
+        metrics_logger.set_properties_from_json(args.custom_properties)
+
+    # add properties about environment of this script
+    metrics_logger.set_platform_properties()
+
+    if args.output:
+        # make sure the output argument exists
+        os.makedirs(args.output, exist_ok=True)
+        
+        # and create your own file inside the output
+        args.output = os.path.join(args.output, "predictions.txt")
 
 
-    with metrics_logger.log_time_block("pandas data loading to numpy"):
+    logger.info(f"Loading data for inferencing")
+    with metrics_logger.log_time_block("time_data_loading"):
         my_data = pd.read_csv(args.data).to_numpy()
 
-    with metrics_logger.log_time_block("treelite model converstion"):
-        model = treelite.Model.load(args.model,model_format='lightgbm')
-        model.export_lib(toolchain= 'gcc', libpath = './mymodel.so',verbose = True, params={'parallel_comp':16})
-        predictor = treelite_runtime.Predictor('./mymodel.so', verbose=True,nthread=args.nthreads)
+    logger.info(f"Converting model to Treelite")
+    with metrics_logger.log_time_block("treelite_model_conversion"):
+        model = treelite.Model.load(
+            args.model,
+            model_format=args.model_format
+        )
+        model.export_lib(
+            toolchain=args.toolchain,
+            libpath='./mymodel.so',
+            verbose=True,
+            params={'parallel_comp':16}
+        )
+        predictor = treelite_runtime.Predictor(
+            './mymodel.so',
+            verbose=True,
+            nthread=args.nthreads
+        )
         dmat = treelite_runtime.DMatrix(my_data)
 
+    logger.info(f"Running .predict()")
     with metrics_logger.log_time_block("treelite prediction"):
         predictor.predict(dmat)
 
-    # optional: close logging session
+    # Important: close logging session before exiting
     metrics_logger.close()
 
 
 def main(cli_args=None):
-    """ Component main function, parses arguments and executes run() function.
+    """Component main function, parses arguments and executes run() function.
 
     Args:
         cli_args (List[str], optional): list of args to feed script, useful for debugging. Defaults to None.
     """
-    # construct arg parser
+    # initialize root logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    console_handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(name)s : %(message)s')
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    # construct arg parser and parse arguments
     parser = get_arg_parser()
     args, unknown_args = parser.parse_known_args(cli_args)
+
+    logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
 
     # run the actual thing
     run(args, unknown_args)
 
 
 if __name__ == "__main__":
-    main()    
+    main()

--- a/tests/scripts/test_treelite_python.py
+++ b/tests/scripts/test_treelite_python.py
@@ -1,0 +1,33 @@
+"""
+Executes the series of scripts end-to-end
+to test LightGBM (python) manual benchmark
+"""
+import os
+import sys
+import tempfile
+from unittest.mock import patch
+
+from scripts.treelite_python import score
+
+# IMPORTANT: see conftest.py for fixtures
+
+def test_treelist_inferencing_script(temporary_dir, regression_inference_sample, regression_model_sample):
+    # create a directory for each output
+    predictions_dir = os.path.join(temporary_dir, "predictions")
+
+    script_args = [
+        "score.py",
+        "--data", regression_inference_sample,
+        "--model", regression_model_sample,
+        "--output", predictions_dir,
+        "--model_format", "lightgbm",
+        "--toolchain", "gcc"
+        #"--toolchain", "msvc"
+    ]
+
+    # replaces sys.argv with test arguments and run main
+    with patch.object(sys, "argv", script_args):
+        score.main()
+
+    # test expected outputs
+    #assert os.path.isfile(os.path.join(predictions_dir, "predictions.txt"))

--- a/tests/scripts/test_treelite_python.py
+++ b/tests/scripts/test_treelite_python.py
@@ -21,8 +21,9 @@ def test_treelist_inferencing_script(temporary_dir, regression_inference_sample,
         "--model", regression_model_sample,
         "--output", predictions_dir,
         "--model_format", "lightgbm",
-        "--toolchain", "gcc"
-        #"--toolchain", "msvc"
+        "--toolchain", "gcc",
+        #"--toolchain", "msvc",
+        "--nthreads", "1",
     ]
 
     # replaces sys.argv with test arguments and run main


### PR DESCRIPTION
Align the script from treelite_python/score.py to the "developer guide" sample.py (with all its goodness).

Created a unit test (just trying to run with some arguments) to validate treelite script.

NOTE: still lots of duplicate code, will work on factoring it later.

See developer guide in the docs https://github.com/microsoft/lightgbm-benchmark/blob/main/docs/Developer-guide.md