### PR TITLE
Updating subprocess.run to consume arguments as a list instead of a string

### DIFF
--- a/src/scripts/lightgbm_cli/score.py
+++ b/src/scripts/lightgbm_cli/score.py
@@ -122,7 +122,7 @@ def run(args, unknown_args=[]):
     logger.info(f"Running .predict()")
     with metrics_logger.log_time_block(metric_name="time_inferencing"):
         lightgbm_cli_call = subprocess_run(
-            " ".join(lightgbm_cli_command),
+            lightgbm_cli_command,
             stdout=PIPE,
             stderr=PIPE,
             universal_newlines=True,


### PR DESCRIPTION
As described in Issue #33, passing arguments to `subprocess.run` as a string yields platform-dependent behavior. In this particular case, `src/scripts/lightgbm_cli/score.py` crashed when running in Linux. 

This PR updates _args_ to be consumed as a list, which is correctly interpreted by all platforms. 


Closes #33 
