### PR TITLE
Check manual docs for consistency with script arguments, add code blocks as panels

### DIFF
--- a/docs/contribute/reporting-guide.md
+++ b/docs/contribute/reporting-guide.md
@@ -104,7 +104,7 @@ Any keyword arg of log_parameters() is submitted as a parameter in mlflow.
 metrics_logger.log_parameters(**lgbm_params)
 ```
 
-#### 4. Compute wall-time using with statement
+### 4. Compute wall-time using with statement
 
 To compute wall time, the `MetricsLogger` class provide a helper method you can use within a `with` statement:
 

--- a/docs/quickstart/manual-benchmark.md
+++ b/docs/quickstart/manual-benchmark.md
@@ -11,54 +11,97 @@
 
 To generate a synthetic dataset based on sklearn:
 
-```sh
-python src/scripts/generate_data/generate.py \
-    --train_samples 30000 \
-    --test_samples 3000 \
-    --inferencing_samples 30000 \
-    --n_features 4000 \
-    --n_informative 400 \
-    --random_state 5 \
-    --output_train ./data/synthetic/train/ \
-    --output_test ./data/synthetic/test/ \
-    --output_inference ./data/synthetic/inference/ \
-    --type regression
-```
+=== "Bash"
+
+    ``` bash
+    python src/scripts/generate_data/generate.py \
+        --train_samples 30000 \
+        --test_samples 3000 \
+        --inferencing_samples 30000 \
+        --n_features 4000 \
+        --n_informative 400 \
+        --random_state 5 \
+        --output_train ./data/synthetic/train/ \
+        --output_test ./data/synthetic/test/ \
+        --output_inference ./data/synthetic/inference/ \
+        --type regression
+    ```
+
+=== "Powershell"
+
+    ``` powershell
+    python src/scripts/generate_data/generate.py `
+        --train_samples 30000 `
+        --test_samples 3000 `
+        --inferencing_samples 30000 `
+        --n_features 4000 `
+        --n_informative 400 `
+        --random_state 5 `
+        --output_train ./data/synthetic/train/ `
+        --output_test ./data/synthetic/test/ `
+        --output_inference ./data/synthetic/inference/ `
+        --type regression
+    ```
+
 
 Note: Running the synthetic data generation script with these parameter values requires at least 4 GB of RAM available and generates a 754 MB training, a 75 MB testing, and a 744 MB inferencing dataset.
 
 ## Run training on synthetic data
 
-```sh
-python src/scripts/lightgbm_python/train.py \
-    --train ./data/synthetic/train/ \
-    --test ./data/synthetic/test/ \
-    --export_model ./data/models/synthetic-1200/ \
-    --objective regression \
-    --boosting_type gbdt \
-    --tree_learner serial \
-    --metric rmse \
-    --num_trees 1200 \
-    --num_leaves 100 \
-    --min_data_in_leaf 400 \
-    --learning_rate 0.3 \
-    --max_bin 16 \
-    --feature_fraction 0.15
-```
+=== "Bash"
+
+    ``` bash
+    python src/scripts/lightgbm_python/train.py \
+        --train ./data/synthetic/train/ \
+        --test ./data/synthetic/test/ \
+        --export_model ./data/models/synthetic-1200/ \
+        --objective regression \
+        --boosting_type gbdt \
+        --tree_learner serial \
+        --metric rmse \
+        --num_trees 100 \
+        --num_leaves 100 \
+        --min_data_in_leaf 400 \
+        --learning_rate 0.3 \
+        --max_bin 16 \
+        --feature_fraction 0.15
+    ```
+
+=== "Powershell"
+
+    ``` powershell
+    python src/scripts/lightgbm_python/train.py `
+        --train ./data/synthetic/train/ `
+        --test ./data/synthetic/test/ `
+        --export_model ./data/models/synthetic-1200/ `
+        --objective regression `
+        --boosting_type gbdt `
+        --tree_learner serial `
+        --metric rmse `
+        --num_trees 100 `
+        --num_leaves 100 `
+        --min_data_in_leaf 400 `
+        --learning_rate 0.3 `
+        --max_bin 16 `
+        --feature_fraction 0.15
+    ```
 
 ## Run inferencing on synthetic data
 
-```sh
-python src/scripts/lightgbm_python/score.py \
-    --data ./data/synthetic/inference/ \
-    --model ./data/models/synthetic-1200/ \
-    --output ./data/outputs/predictions/
-```
+=== "Bash"
 
-```sh
-python src/scripts/lightgbm_cli/score.py \
-    --lightgbm_exec ./build/windows/x64/Release/lightgbm.exe \
-    --data ./data/synthetic/inference/ \
-    --model ./data/models/synthetic-1200/ \
-    --output ./data/outputs/predictions/
-```
+    ```bash
+    python src/scripts/lightgbm_python/score.py \
+        --data ./data/synthetic/inference/ \
+        --model ./data/models/synthetic-1200/ \
+        --output ./data/outputs/predictions/
+    ```
+
+=== "Powershell"
+
+    ``` powershell
+    python src/scripts/lightgbm_python/score.py `
+        --data ./data/synthetic/inference/ `
+        --model ./data/models/synthetic-1200/ `
+        --output ./data/outputs/predictions/
+    ```

--- a/docs/quickstart/manual-benchmark.md
+++ b/docs/quickstart/manual-benchmark.md
@@ -86,7 +86,7 @@ Note: Running the synthetic data generation script with these parameter values r
         --feature_fraction 0.15
     ```
 
-## Run inferencing on synthetic data
+## Run inferencing on synthetic data (lightgbm python)
 
 === "Bash"
 
@@ -101,6 +101,30 @@ Note: Running the synthetic data generation script with these parameter values r
 
     ``` powershell
     python src/scripts/lightgbm_python/score.py `
+        --data ./data/synthetic/inference/ `
+        --model ./data/models/synthetic-1200/ `
+        --output ./data/outputs/predictions/
+    ```
+
+## Run inferencing on synthetic data (lightgbm cli)
+
+If you have a local installation of lightgbm cli, run the `lightgbm_cli` script by pointing to the lightgbm binaries (works for both linux and windows).
+
+=== "Bash"
+
+    ```bash
+    python src/scripts/lightgbm_cli/score.py \
+        --lightgbm_exec ./build/windows/x64/Release/lightgbm.exe \
+        --data ./data/synthetic/inference/ \
+        --model ./data/models/synthetic-1200/ \
+        --output ./data/outputs/predictions/
+    ```
+
+=== "Powershell"
+
+    ``` powershell
+    python src/scripts/lightgbm_cli/score.py `
+        --lightgbm_exec ./build/windows/x64/Release/lightgbm.exe `
         --data ./data/synthetic/inference/ `
         --model ./data/models/synthetic-1200/ `
         --output ./data/outputs/predictions/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,11 +21,13 @@ theme:
   name: material
 
 markdown_extensions:
-- pymdownx.highlight:
-    linenums: true
-    linenums_style: pymdownx-inline
+- pymdownx.tabbed
 - pymdownx.superfences
 - pymdownx.snippets
+- pymdownx.highlight:
+    use_pygments: true
+    linenums: true
+    linenums_style: pymdownx-inline
 # https://github.com/mkdocs/mkdocs/issues/777
 - markdown_include.include:
     base_path: .


### PR DESCRIPTION
I just reviewed the manual instructions to ensure they were still working considering the latest changes in the script arguments. They do :)
Used the opportunity to revise the docs engine and add code blocks as panels whenever there's 2 languages involved :)

This is what it will look like:
![image](https://user-images.githubusercontent.com/1378422/133163136-0bba27a0-8d88-42ec-bb80-f00f484672a6.png)
