### PR TITLE
Fix: add runsettings everywhere

### DIFF
--- a/pipelines/azureml/conf/modules/benchmark.yaml
+++ b/pipelines/azureml/conf/modules/benchmark.yaml
@@ -1,6 +1,6 @@
 # @package _group_
 manifest:
-  - name: "generate_data"
+  - name: "generate_synthetic_data"
     version: null
     yaml: "generate_data/generate_spec.yaml"
   - name: "lightgbm_python_train"

--- a/pipelines/azureml/pipelines/lightgbm_e2e_synthetic.py
+++ b/pipelines/azureml/pipelines/lightgbm_e2e_synthetic.py
@@ -136,6 +136,7 @@ class LightGBMEndToEnd(AMLPipelineHelper):
                 verbose = False,
                 custom_properties = benchmark_custom_properties
             )
+            self.apply_smart_runsettings(generate_data_step)
             
             lightgbm_train_step = lightgbm_train_module(
                 train = generate_data_step.outputs.output_train,
@@ -156,6 +157,7 @@ class LightGBMEndToEnd(AMLPipelineHelper):
                 verbose = False,
                 custom_properties = benchmark_custom_properties
             )
+            self.apply_smart_runsettings(lightgbm_train_step)
 
             # call module with all the right arguments
             lightgbm_score_step = lightgbm_score_module(

--- a/pipelines/azureml/pipelines/lightgbm_e2e_synthetic.py
+++ b/pipelines/azureml/pipelines/lightgbm_e2e_synthetic.py
@@ -88,7 +88,7 @@ class LightGBMEndToEnd(AMLPipelineHelper):
         # load the right module depending on config
 
         # Data modules
-        generate_data_module = self.module_load("generate_data")
+        generate_data_module = self.module_load("generate_synthetic_data")
 
         # Training modules
         lightgbm_train_module = self.module_load("lightgbm_python_train")


### PR DESCRIPTION
The usual line calling apply_smart_runsettings() was missing in 2 of the modules of e2e pipeline. It was running on the default compute.