### PR TITLE
implement callbacks to capture lightgbm metrics

### DIFF
--- a/src/common/lightgbm.py
+++ b/src/common/lightgbm.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+This classes provide help to integrate lightgbm
+"""
+import lightgbm
+import logging
+
+class LightGBMCallbackHandler():
+    """ This class handles LightGBM callbacks for recording metrics. """
+    def __init__(self, metrics_logger, node_index=0):
+        """
+        Args:
+            metrics_logger (common.metrics.MetricsLogger)
+            node_index (int) : if mpi, provide index of the node
+        """
+        self.metrics = {}
+        self.metrics_logger = metrics_logger
+        self.node_index = node_index
+        self.logger = logging.getLogger(__name__)
+    
+    def callback(self, env: lightgbm.callback.CallbackEnv) -> None:
+        """
+        See https://lightgbm.readthedocs.io/en/latest/_modules/lightgbm/callback.html
+        """
+        # let's record in the object for future use
+        self.metrics[env.iteration] = env.evaluation_result_list
+
+        # loop on all the evaluation results tuples
+        for data_name, eval_name, result, _ in env.evaluation_result_list:
+            # log each as a distinct metric
+            self.metrics_logger.log_metric(
+                key=f"node_{self.node_index}.{data_name}.{eval_name}",
+                value=result,
+                step=env.iteration # provide iteration as step in mlflow
+            )

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -52,12 +52,12 @@ class MetricsLogger():
         self._logger.info(f"Finalizing MLFLOW [session='{self._session_name}']")
         mlflow.end_run()
 
-    def log_metric(self, key, value):
+    def log_metric(self, key, value, step=None):
         self._logger.debug(f"mlflow[session={self._session_name}].log_metric({key},{value})")
         # NOTE: there's a limit to the name of a metric
         if len(key) > 50:
             key = key[:50]
-        mlflow.log_metric(key, value)
+        mlflow.log_metric(key, value, step=step)
 
     def set_properties(self, **kwargs):
         """ Set properties/tags for the session """

--- a/src/scripts/lightgbm_python/train.py
+++ b/src/scripts/lightgbm_python/train.py
@@ -22,7 +22,7 @@ if COMMON_ROOT not in sys.path:
 # useful imports from common
 from common.metrics import MetricsLogger
 from common.io import input_file_path
-
+from common.lightgbm import LightGBMCallbackHandler
 
 def get_arg_parser(parser=None):
     """Adds component/module arguments to a given argument parser.
@@ -98,6 +98,7 @@ def run(args, unknown_args=[]):
     # get Metrics logger for benchmark metrics
     # below: initialize reporting of metrics with a custom session name
     metrics_logger = MetricsLogger("lightgbm_python.score")
+    callbacks_handler = LightGBMCallbackHandler(metrics_logger=metrics_logger)
 
     # add common properties to the session
     metrics_logger.set_properties(
@@ -146,7 +147,7 @@ def run(args, unknown_args=[]):
             lgbm_params,
             train_data,
             valid_sets = val_data,
-            callbacks=[]
+            callbacks=[callbacks_handler.callback]
         )
 
     if args.export_model:

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -20,9 +20,9 @@ def test_metrics_logger_log_metric(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger()
 
-    metrics_logger.log_metric("foo", "bar")
+    metrics_logger.log_metric("foo", "bar", step=16)
     mlflow_log_metric_mock.assert_called_with(
-        "foo", "bar"
+        "foo", "bar", step=16
     )
 
 
@@ -38,10 +38,10 @@ def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
     assert len(short_metric_key), 50
 
     metrics_logger.log_metric(
-        metric_key, "bar"
+        metric_key, "bar", step=15
     )
     mlflow_log_metric_mock.assert_called_with(
-        short_metric_key, "bar"
+        short_metric_key, "bar", step=15
     )
 
 


### PR DESCRIPTION
This uses lightgbm callbacks to record training metrics in mlflow.

This shows up in AzureML nicely.