### PR TITLE
Implement optional prefix to metrics in MetricsLogger

### DIFF
--- a/src/common/lightgbm.py
+++ b/src/common/lightgbm.py
@@ -9,15 +9,14 @@ import logging
 
 class LightGBMCallbackHandler():
     """ This class handles LightGBM callbacks for recording metrics. """
-    def __init__(self, metrics_logger, metrics_prefix=None):
+    def __init__(self, metrics_logger):
         """
         Args:
             metrics_logger (common.metrics.MetricsLogger)
-            metrics_prefix (str) : provide a prefix for all metrics (ex: node number)
+            node_index (int) : if mpi, provide index of the node
         """
         self.metrics = {}
         self.metrics_logger = metrics_logger
-        self.metrics_prefix = metrics_prefix
         self.logger = logging.getLogger(__name__)
     
     def callback(self, env: lightgbm.callback.CallbackEnv) -> None:
@@ -29,13 +28,9 @@ class LightGBMCallbackHandler():
 
         # loop on all the evaluation results tuples
         for data_name, eval_name, result, _ in env.evaluation_result_list:
-            metric_key = f"{data_name}.{eval_name}"
-            if self.metrics_prefix:
-                metric_key = self.metrics_prefix + metric_key
-
             # log each as a distinct metric
             self.metrics_logger.log_metric(
-                key=metric_key,
+                key=f"{data_name}.{eval_name}",
                 value=result,
                 step=env.iteration # provide iteration as step in mlflow
             )

--- a/src/common/lightgbm.py
+++ b/src/common/lightgbm.py
@@ -9,15 +9,15 @@ import logging
 
 class LightGBMCallbackHandler():
     """ This class handles LightGBM callbacks for recording metrics. """
-    def __init__(self, metrics_logger, node_index=0):
+    def __init__(self, metrics_logger, metrics_prefix=None):
         """
         Args:
             metrics_logger (common.metrics.MetricsLogger)
-            node_index (int) : if mpi, provide index of the node
+            metrics_prefix (str) : provide a prefix for all metrics (ex: node number)
         """
         self.metrics = {}
         self.metrics_logger = metrics_logger
-        self.node_index = node_index
+        self.metrics_prefix = metrics_prefix
         self.logger = logging.getLogger(__name__)
     
     def callback(self, env: lightgbm.callback.CallbackEnv) -> None:
@@ -29,9 +29,13 @@ class LightGBMCallbackHandler():
 
         # loop on all the evaluation results tuples
         for data_name, eval_name, result, _ in env.evaluation_result_list:
+            metric_key = f"{data_name}.{eval_name}"
+            if self.metrics_prefix:
+                metric_key = self.metrics_prefix + metric_key
+
             # log each as a distinct metric
             self.metrics_logger.log_metric(
-                key=f"node_{self.node_index}.{data_name}.{eval_name}",
+                key=metric_key,
                 value=result,
                 step=env.iteration # provide iteration as step in mlflow
             )

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -32,7 +32,7 @@ class MetricsLogger():
 
     def __new__(cls, session_name=None, metrics_prefix=None):
         """ Create a new instance of the Singleton if necessary """
-        if cls._instance is None:
+        if not cls._initialized:
             # if this is the first time we're initializing
             cls._instance = super(MetricsLogger, cls).__new__(cls)
             cls._metrics_prefix = metrics_prefix
@@ -44,18 +44,24 @@ class MetricsLogger():
                 cls._session_name = session_name
             cls._logger.info(f"Initializing MLFLOW [session='{cls._session_name}', metrics_prefix={cls._metrics_prefix}]")
             mlflow.start_run()
+            cls._initialized = True
         else:
-            # if this is not the first time
-            if cls._metrics_prefix != metrics_prefix:
-                cls._logger.warning(f"New creation of MetricsLogger() with a new prefix {cls._metrics_prefix} != {metrics_prefix}")
-            cls._metrics_prefix = metrics_prefix
+            # if this is not the first time, and things are already initialized
+            if not cls._metrics_prefix:
+                cls._logger.warning(f"New creation of MetricsLogger() with a new prefix {metrics_prefix}")
+                cls._metrics_prefix = metrics_prefix
             pass
 
         return cls._instance
 
-    def close(self):
-        self._logger.info(f"Finalizing MLFLOW [session='{self._session_name}']")
-        mlflow.end_run()
+    @classmethod
+    def close(cls):
+        if cls._initialized:
+            cls._logger.info(f"Finalizing MLFLOW [session='{cls._session_name}']")
+            mlflow.end_run()
+            cls._initialized = False
+        else:
+            cls._logger.warning(f"Call to finalize MLFLOW [session='{cls._session_name}'] that was never initialized.")
 
     def log_metric(self, key, value, step=None):
         if self._metrics_prefix:

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -27,23 +27,28 @@ class MetricsLogger():
     _initialized = False
     _instance = None
     _session_name = None
+    _metrics_prefix = None
     _logger = logging.getLogger(__name__)
 
-    def __new__(cls, session_name=None):
+    def __new__(cls, session_name=None, metrics_prefix=None):
         """ Create a new instance of the Singleton if necessary """
         if cls._instance is None:
             # if this is the first time we're initializing
             cls._instance = super(MetricsLogger, cls).__new__(cls)
+            cls._metrics_prefix = metrics_prefix
             if not cls._session_name:
                 # if no previously recorded session name
                 cls._session_name = session_name
             elif session_name:
                 # if new session name specified, overwrite
                 cls._session_name = session_name
-            cls._logger.info(f"Initializing MLFLOW [session='{cls._session_name}']")
+            cls._logger.info(f"Initializing MLFLOW [session='{cls._session_name}', metrics_prefix={cls._metrics_prefix}]")
             mlflow.start_run()
         else:
             # if this is not the first time
+            if cls._metrics_prefix != metrics_prefix:
+                cls._logger.warning(f"New creation of MetricsLogger() with a new prefix {cls._metrics_prefix} != {metrics_prefix}")
+            cls._metrics_prefix = metrics_prefix
             pass
 
         return cls._instance
@@ -53,6 +58,9 @@ class MetricsLogger():
         mlflow.end_run()
 
     def log_metric(self, key, value, step=None):
+        if self._metrics_prefix:
+            key = self._metrics_prefix + key
+
         self._logger.debug(f"mlflow[session={self._session_name}].log_metric({key},{value})")
         # NOTE: there's a limit to the name of a metric
         if len(key) > 50:

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -27,6 +27,17 @@ def test_metrics_logger_log_metric(mlflow_log_metric_mock):
 
 
 @patch('mlflow.log_metric')
+def test_metrics_logger_log_metric(mlflow_log_metric_mock):
+    """ Tests MetricsLogger().log_metric() """
+    metrics_logger = MetricsLogger(metrics_prefix="foo/")
+
+    metrics_logger.log_metric("foo", "bar", step=16)
+    mlflow_log_metric_mock.assert_called_with(
+        "foo/foo", "bar", step=16
+    )
+
+
+@patch('mlflow.log_metric')
 def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger()


### PR DESCRIPTION
The goal is to introduce a prefix for all calls to mlflow.log_metric(). This will be useful in the mpi scenario where we want to add the node number in front of our metrics.

callbacks had this node_index parameter, this is now redundant if we set prefix in metrics_logger directly, so node_index has been removed.