### PR TITLE
Enable data generation pipeline to generate multiple datasets in one run

### DIFF
--- a/pipelines/azureml/conf/experiments/data-generation.yaml
+++ b/pipelines/azureml/conf/experiments/data-generation.yaml
@@ -30,12 +30,14 @@ data_generation:
   benchmark_name: "benchmark-dev"
 
   # DATA
-  learning_task: "regression"
-  train_samples: 100000
-  test_samples: 10000
-  inferencing_samples: 10000
-  n_features: 4000
-  n_informative: 4000
+  tasks:
+    - task: "regression"
+      train_samples: 100000
+      test_samples: 10000
+      inferencing_samples: 10000
+      n_features: 4000
+      n_informative: 4000
+
   data_register_train_as: "synthetic-regr-4000cols-train"
   data_register_test_as: "synthetic-regr-4000cols-test"
   data_register_inference_as: "synthetic-regr-4000cols-inference"

--- a/pipelines/azureml/conf/experiments/data-generation.yaml
+++ b/pipelines/azureml/conf/experiments/data-generation.yaml
@@ -35,9 +35,20 @@ data_generation:
       train_samples: 100000
       test_samples: 10000
       inferencing_samples: 10000
-      n_features: 4000
-      n_informative: 4000
+      n_features: 10
+      n_informative: 10
+    - task: "regression"
+      train_samples: 100000
+      test_samples: 10000
+      inferencing_samples: 10000
+      n_features: 100
+      n_informative: 100
+    - task: "regression"
+      train_samples: 100000
+      test_samples: 10000
+      inferencing_samples: 10000
+      n_features: 1000
+      n_informative: 1000
 
-  data_register_train_as: "synthetic-regr-4000cols-train"
-  data_register_test_as: "synthetic-regr-4000cols-test"
-  data_register_inference_as: "synthetic-regr-4000cols-inference"
+  register_outputs: true
+  register_outputs_prefix: "synthetic" # "{prefix}-{task}-{n_features}cols-{train|test|inference}"

--- a/src/common/data.py
+++ b/src/common/data.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from omegaconf import MISSING
+from typing import Optional
+from enum import Enum
+
+class LearningTask(Enum):
+    regression = "regression"
+    classification = "classification"
+    ranking = "ranking"
+
+@dataclass
+class synthetic_data_config:
+    task: LearningTask = MISSING
+    train_samples: int = MISSING
+    test_samples: int = MISSING
+    inferencing_samples: int = MISSING
+    n_features: int = MISSING
+    n_informative: Optional[int] = None

--- a/src/common/data.py
+++ b/src/common/data.py
@@ -1,16 +1,10 @@
 from dataclasses import dataclass
 from omegaconf import MISSING
 from typing import Optional
-from enum import Enum
-
-class LearningTask(Enum):
-    regression = "regression"
-    classification = "classification"
-    ranking = "ranking"
 
 @dataclass
 class synthetic_data_config:
-    task: LearningTask = MISSING
+    task: str = MISSING
     train_samples: int = MISSING
     test_samples: int = MISSING
     inferencing_samples: int = MISSING


### PR DESCRIPTION
- implement a config for the data generation "task" (dataclass)
- change data generation config to use this task as a list
- update pipeline so that build() provides a generic data generation pipeline, and pipeline_instance() extends the pipeline as much as needed to complete all the tasks