### PR TITLE
allow partition script to re-partition data

### DIFF
--- a/src/common/io.py
+++ b/src/common/io.py
@@ -47,6 +47,7 @@ class PartitioningEngine():
         current_partition_index = 0
         self.logger.info(f"Creating partition {current_partition_index}")
         for input_file in input_files:
+            self.logger.info(f"Opening input file {input_file}")
             with open(input_file, "r", encoding="utf-8") as input_handler:
                 for line in input_handler:
                     if partition_size > 0 and current_partition_size >= partition_size:
@@ -66,6 +67,7 @@ class PartitioningEngine():
 
         current_index = 0
         for input_file in input_files:
+            self.logger.info(f"Opening input file {input_file}")
             with open(input_file, "r", encoding="utf-8") as input_handler:
                 for line in input_handler:
                     partition_files[current_index % partition_count].write(line)

--- a/src/scripts/partition_data/partition.py
+++ b/src/scripts/partition_data/partition.py
@@ -41,7 +41,7 @@ def get_arg_parser(parser=None):
 
     # add arguments that are specific to the module
     group = parser.add_argument_group('Partitioning arguments')
-    group.add_argument("--input", dest="input", type=input_file_path, required=True, help="file/directory to split")
+    group.add_argument("--input", dest="input", type=str, required=True, help="file/directory to split")
     group.add_argument("--output", dest="output", type=str, help="location to store partitioned files", required=True)
     group.add_argument("--mode", type=str, choices=PartitioningEngine.PARTITION_MODES, required=True, help="Partitioning mode")
     group.add_argument("--number", type=int, required=True, help="If roundrobin number of partition, if chunk number of records per partition")


### PR DESCRIPTION
In previous code, we were limiting the inputs of partition.py to be one single file. But the code already supported having multiple input files (to re-partition them).

This simple fix allows that to be possible now.