### PR TITLE
remove eval_at from standard component params

### DIFF
--- a/pipelines/azureml/conf/experiments/lightgbm_training/cpu-custom.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/cpu-custom.yaml
@@ -45,7 +45,6 @@ lightgbm_training:
     # lightgbm training parameters
     objective: "regression"
     metric: "rmse"
-    eval_at: "1,3,5"
     boosting: "gbdt"
     tree_learner: "data"
     num_iterations: 100

--- a/pipelines/azureml/conf/experiments/lightgbm_training/cpu.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/cpu.yaml
@@ -46,7 +46,6 @@ lightgbm_training:
     # lightgbm training parameters
     objective: "regression"
     metric: "rmse"
-    eval_at: "1,3,5"
     boosting: "gbdt"
     tree_learner: "data"
     num_iterations: 100

--- a/pipelines/azureml/conf/experiments/lightgbm_training/gpu.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/gpu.yaml
@@ -45,7 +45,6 @@ lightgbm_training:
     # lightgbm training parameters
     objective: "regression"
     metric: "rmse"
-    eval_at: "1,3,5"
     boosting: "gbdt"
     tree_learner: "data"
     num_iterations: 100

--- a/pipelines/azureml/conf/experiments/lightgbm_training/sweep.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/sweep.yaml
@@ -45,7 +45,6 @@ lightgbm_training:
     # fixedlightgbm training parameters
     objective: "regression"
     metric: "rmse"
-    eval_at: "1,3,5"
     boosting: "gbdt"
     tree_learner: "data"
     #custom_params:

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -57,7 +57,6 @@ class training_variant:
     metric: str = MISSING
     boosting: str = MISSING
     tree_learner: str = MISSING
-    eval_at: Optional[str] = None
 
     # sweepable training parameters
     # NOTE: need to be str so they can be parsed (ex: 'choice(100,200)')

--- a/src/scripts/lightgbm_python/train.py
+++ b/src/scripts/lightgbm_python/train.py
@@ -64,7 +64,6 @@ def get_arg_parser(parser=None):
     group_lgbm.add_argument("--boosting_type", required=True, type=str)
     group_lgbm.add_argument("--tree_learner", required=True, type=str)
     group_lgbm.add_argument("--label_gain", required=False, type=str, default=None)
-    group_lgbm.add_argument("--eval_at", required=False, type=str, default="1,2,3,4,5")
     group_lgbm.add_argument("--num_trees", required=True, type=int)
     group_lgbm.add_argument("--num_leaves", required=True, type=int)
     group_lgbm.add_argument("--min_data_in_leaf", required=True, type=int)

--- a/src/scripts/lightgbm_python/train_spec.yaml
+++ b/src/scripts/lightgbm_python/train_spec.yaml
@@ -79,10 +79,6 @@ inputs:
     type: String
     optional: True
     description: https://lightgbm.readthedocs.io/en/latest/Parameters.html#label_gain
-  eval_at:
-    type: String
-    optional: True
-    description: "https://lightgbm.readthedocs.io/en/latest/Parameters.html#eval_at"
   num_iterations:
     type: Integer
     min: 1
@@ -149,7 +145,6 @@ launcher:
     --device_type {inputs.device_type}
     --objective {inputs.objective}
     --metric {inputs.metric}
-    [--eval_at {inputs.eval_at}]
     [--label_gain {inputs.label_gain}]
     [--custom_params {inputs.custom_params}]
     --boosting {inputs.boosting}


### PR DESCRIPTION
it's not a major parameter, and users can still use custom_params to override it.