### PR TITLE
add yaml config in pipeline description

### DIFF
--- a/pipelines/azureml/pipelines/data_generation.py
+++ b/pipelines/azureml/pipelines/data_generation.py
@@ -10,7 +10,7 @@ import os
 import sys
 import json
 from dataclasses import dataclass
-from omegaconf import MISSING
+from omegaconf import MISSING, OmegaConf
 from typing import Optional, List
 from azure.ml.component import dsl
 from shrike.pipeline.pipeline_helper import AMLPipelineHelper
@@ -141,10 +141,16 @@ class DataGenerationPipeline(AMLPipelineHelper):
         benchmark_custom_properties = json.dumps({
             'benchmark_name' : config.data_generation.benchmark_name
         })
+        full_pipeline_description="\n".join([
+            "Generate all datasets for lightgbm benchmark",
+            "```yaml""",
+            OmegaConf.to_yaml(config),
+            "```"
+        ])
 
         # Here you should create an instance of a pipeline function (using your custom config dataclass)
         @dsl.pipeline(name="generate_all_datasets", # pythonic name
-                      description="Generate all datasets for lightgbm benchmark",
+                      description=full_pipeline_description,
                       default_datastore=config.compute.noncompliant_datastore)
         def generate_all_tasks():
             for generation_task in config.data_generation.tasks:

--- a/pipelines/azureml/pipelines/lightgbm_inferencing.py
+++ b/pipelines/azureml/pipelines/lightgbm_inferencing.py
@@ -13,7 +13,7 @@ import os
 import sys
 import json
 from dataclasses import dataclass
-from omegaconf import MISSING
+from omegaconf import MISSING, OmegaConf
 from typing import Optional, List
 from azure.ml.component import dsl
 from shrike.pipeline.pipeline_helper import AMLPipelineHelper
@@ -177,9 +177,16 @@ class LightGBMInferencing(AMLPipelineHelper):
         Returns:
             azureml.core.Pipeline: the instance constructed with its inputs and params.
         """
+        full_pipeline_description="\n".join([
+            "Inferencing on all specified tasks (see yaml below).",
+            "```yaml""",
+            OmegaConf.to_yaml(config),
+            "```"
+        ])
+
         # Here you should create an instance of a pipeline function (using your custom config dataclass)
         @dsl.pipeline(name="inferencing_all_tasks", # pythonic name
-                      description="Inferencing on all specified tasks",
+                      description=full_pipeline_description,
                       default_datastore=config.compute.noncompliant_datastore)
         def inferencing_all_tasks():
             for inferencing_task in config.lightgbm_inferencing.tasks:

--- a/pipelines/azureml/pipelines/lightgbm_training.py
+++ b/pipelines/azureml/pipelines/lightgbm_training.py
@@ -10,7 +10,7 @@ import os
 import sys
 import json
 from dataclasses import dataclass
-from omegaconf import MISSING
+from omegaconf import MISSING, OmegaConf
 from typing import Optional, Any, List
 from azure.ml.component import dsl
 from shrike.pipeline.pipeline_helper import AMLPipelineHelper
@@ -428,9 +428,16 @@ class LightGBMTraining(AMLPipelineHelper):
         Returns:
             azureml.core.Pipeline: the instance constructed with its inputs and params.
         """
+        full_pipeline_description="\n".join([
+            "Training on all specified tasks (see yaml below).",
+            "```yaml""",
+            OmegaConf.to_yaml(config),
+            "```"
+        ])
+
         # creating an overall pipeline using pipeline_function for each task given
         @dsl.pipeline(name="training_all_tasks", # pythonic name
-                      description="Training on all specified tasks",
+                      description=full_pipeline_description,
                       default_datastore=config.compute.noncompliant_datastore)
         def training_all_tasks():
             # loop on all training tasks


### PR DESCRIPTION
This PR uses dsl.pipeline(description="") to inject the full content of the config dictionary as a yaml output in the description, so that it shows in AzureML.