### PR TITLE
Use arguments in docker files in order to build from PR properly

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -37,8 +37,6 @@ jobs:
 
     - name: Query Git branch name
       uses: petehouston/github-actions-query-branch-name@v1.2
-      with:
-        name: queryBranch
   
     - name: Check branch name
       run: |-

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -37,9 +37,12 @@ jobs:
 
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo ::set-output name=short_ref::${GITHUB_REF#refs/*/}
       id: extract_branch
-        
+
+    - name: Check branch name
+      run: echo ${{ steps.extract_branch.outputs.branch }}
+  
     - uses: marceloprado/has-changed-path@v1
       id: dockerfile-changed
       with:

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -35,6 +35,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+        
     - uses: marceloprado/has-changed-path@v1
       id: dockerfile-changed
       with:
@@ -42,7 +47,7 @@ jobs:
 
     - name: Build the Docker image
       if: steps.dockerfile-changed.outputs.changed == 'true'
-      run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s)
+      run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s) --build-arg lightgbm_benchmark_branch=${{ steps.extract_branch.outputs.branch }}
       working-directory: docker/
 
   windows_container_build:

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -35,13 +35,19 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Extract branch name
-      shell: bash
-      run: echo ::set-output name=short_ref::${GITHUB_REF#refs/*/}
-      id: extract_branch
-
+    - name: Query Git branch name
+      uses: petehouston/github-actions-query-branch-name@v1.2
+      with:
+        name: queryBranch
+  
     - name: Check branch name
-      run: echo ${{ steps.extract_branch.outputs.branch }}
+        run: |-
+          echo "GIT_BRANCH_NAME = $GIT_BRANCH_NAME"
+          echo "GIT_BRANCH_NAME_HEAD = $GIT_BRANCH_NAME_BEAD"
+          echo "GIT_BRANCH_NAME_BASE = $GIT_BRANCH_NAME_BASE"
+          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name }}"
+          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_head }}"
+          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_base }}"
   
     - uses: marceloprado/has-changed-path@v1
       id: dockerfile-changed
@@ -50,7 +56,7 @@ jobs:
 
     - name: Build the Docker image
       if: steps.dockerfile-changed.outputs.changed == 'true'
-      run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s) --build-arg lightgbm_benchmark_branch=${{ steps.extract_branch.outputs.branch }}
+      run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s) --build-arg lightgbm_benchmark_branch=$GIT_BRANCH_NAME
       working-directory: docker/
 
   windows_container_build:

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -41,13 +41,13 @@ jobs:
         name: queryBranch
   
     - name: Check branch name
-        run: |-
-          echo "GIT_BRANCH_NAME = $GIT_BRANCH_NAME"
-          echo "GIT_BRANCH_NAME_HEAD = $GIT_BRANCH_NAME_BEAD"
-          echo "GIT_BRANCH_NAME_BASE = $GIT_BRANCH_NAME_BASE"
-          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name }}"
-          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_head }}"
-          echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_base }}"
+      run: |-
+        echo "GIT_BRANCH_NAME = $GIT_BRANCH_NAME"
+        echo "GIT_BRANCH_NAME_HEAD = $GIT_BRANCH_NAME_BEAD"
+        echo "GIT_BRANCH_NAME_BASE = $GIT_BRANCH_NAME_BASE"
+        echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name }}"
+        echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_head }}"
+        echo "Branch name: ${{ steps.queryBranch.outputs.git_branch_name_base }}"
   
     - uses: marceloprado/has-changed-path@v1
       id: dockerfile-changed

--- a/docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
@@ -4,8 +4,51 @@ LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.2.1-patch/20211108.1"
 # Those arguments will NOT be used by AzureML
 # they are here just to allow for lightgbm-benchmark build to actually check
 # dockerfiles in a PR against their actual branch
-ARG lightgbm_branch=tags/v3.2.1
+ARG lightgbm_version="3.2.1"
 ARG lightgbm_benchmark_branch=main
+
+RUN apt-get update && \
+    apt-get -y install build-essential cmake
+
+# LIGHTGBM EXEC AND LIBRARY
+
+# Clone lightgbm official repository (master branch)
+RUN git clone --recursive https://github.com/microsoft/LightGBM && \
+    cd LightGBM && \
+    git checkout tags/v${lightgbm_version}
+
+# Download and apply a particular patch
+RUN cd /LightGBM && \
+    wget https://raw.githubusercontent.com/microsoft/lightgbm-benchmark/32cbb007b61f5bed89af1423c7da250607726a35/pipelines/azureml_sdk15/components/lightgbm_python_custom/lightgbm_custom.python.patch && \
+    git apply --whitespace=fix ./lightgbm_custom.python.patch
+
+# https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
+RUN cd /LightGBM && \
+    mkdir build && \
+    cd build && \
+    cmake -DUSE_MPI=ON .. && \
+    make -j$(nproc)
+
+# Prepend path to LightGBM LIB
+ENV PATH /LightGBM:$PATH
+
+# building lightgbm-benchmark binaries
+RUN git clone --recursive https://github.com/microsoft/lightgbm-benchmark.git && \
+    cd lightgbm-benchmark && \
+    git checkout ${lightgbm_benchmark_branch}
+
+# assuming lightgbm lib+includes are installed on the system
+RUN cd /lightgbm-benchmark/src/binaries/ && \
+    mkdir build && \
+    cd build && \
+    cmake -DLIGHTGBM_INC=/LightGBM/include -DLIGHTGBM_LIB=/LightGBM .. && \
+    cmake --build . --target lightgbm_predict --config Release
+
+# provide env variable with path to built binaries
+ENV LIGHTGBM_BENCHMARK_BINARIES_PATH /lightgbm-benchmark/src/binaries/build
+RUN ls -l $LIGHTGBM_BENCHMARK_BINARIES_PATH
+
+## ANACONDA ENVIRONMENT
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -28,23 +71,12 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
-# install lightgbm with pip
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0'
 
-# Clone lightgbm official repository (master branch)
-RUN git clone --recursive https://github.com/microsoft/LightGBM && \
-    cd LightGBM && \
-    git checkout ${lightgbm_branch}
-
-# Download and apply a particular patch
-RUN cd /LightGBM && \
-    wget https://raw.githubusercontent.com/microsoft/lightgbm-benchmark/32cbb007b61f5bed89af1423c7da250607726a35/pipelines/azureml_sdk15/components/lightgbm_python_custom/lightgbm_custom.python.patch && \
-    git apply --whitespace=fix ./lightgbm_custom.python.patch
-
-# Build lightgbm with custom patch applied
-RUN cd /LightGBM/python-package && \
-    python setup.py install --mpi
+# Install LightGBM Python API from build
+RUN cd /LightGBM/python-package/ && \
+    python setup.py install --precompile
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
@@ -1,4 +1,11 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
+LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.2.1-patch/20211108.1"
+
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_branch=tags/v3.2.1
+ARG lightgbm_benchmark_branch=main
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -15,22 +22,20 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'lightgbm~=3.2.0' \
-                'dask~=2021.6.0' \
-                'distributed~=2021.6.0' \
-                'dask-ml~=1.9.0' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0'
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
+                'mpi4py==3.1.1'
 
+# install lightgbm with pip
 RUN pip install --upgrade pip setuptools wheel && \
-    pip install 'cmake==3.21.0' 
+    pip install 'cmake==3.21.0'
 
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout tags/v3.2.1
+    git checkout ${lightgbm_branch}
 
 # Download and apply a particular patch
 RUN cd /LightGBM && \

--- a/docker/lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
@@ -1,5 +1,12 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20211012.v1
-LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.2.1/20211029.1"
+LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.2.1/20211108.1"
+
+
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_branch=tags/v3.3.0
+ARG lightgbm_benchmark_branch=main
 
 RUN apt-get update && \
     apt-get -y install build-essential cmake
@@ -9,7 +16,7 @@ RUN apt-get update && \
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout tags/v3.2.1
+    git checkout ${lightgbm_branch}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 RUN cd /LightGBM && \
@@ -22,7 +29,9 @@ RUN cd /LightGBM && \
 ENV PATH /LightGBM:$PATH
 
 # building lightgbm-benchmark binaries
-RUN git clone --recursive https://github.com/microsoft/lightgbm-benchmark.git
+RUN git clone --recursive https://github.com/microsoft/lightgbm-benchmark.git && \
+    cd lightgbm-benchmark && \
+    git checkout ${lightgbm_benchmark_branch}
 
 # assuming lightgbm lib+includes are installed on the system
 RUN cd /lightgbm-benchmark/src/binaries/ && \

--- a/docker/lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
@@ -1,11 +1,10 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20211012.v1
 LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.2.1/20211108.1"
 
-
 # Those arguments will NOT be used by AzureML
 # they are here just to allow for lightgbm-benchmark build to actually check
 # dockerfiles in a PR against their actual branch
-ARG lightgbm_branch=tags/v3.3.0
+ARG lightgbm_version="3.2.1"
 ARG lightgbm_benchmark_branch=main
 
 RUN apt-get update && \
@@ -16,7 +15,7 @@ RUN apt-get update && \
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout ${lightgbm_branch}
+    git checkout tags/v${lightgbm_version}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 RUN cd /LightGBM && \
@@ -70,6 +69,9 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0'
 
-# https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#install-python-interface-optional
+# Install LightGBM Python API from build
 RUN cd /LightGBM/python-package/ && \
     python setup.py install --precompile
+
+# This is needed for mpi to locate libpython
+ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
 LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.2.1/20211108.1"
 
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.2.1"
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
 # Create conda environment
@@ -25,7 +30,7 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==3.2.1' --install-option=--mpi
+    pip install 'lightgbm==${lightgbm_version}' --install-option=--mpi
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
-LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.2.1/20211029.1"
+LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.2.1/20211108.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -16,16 +16,16 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==3.3.0' --install-option=--mpi
+    pip install 'lightgbm==3.2.1' --install-option=--mpi
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
@@ -30,7 +30,7 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==${lightgbm_version}' --install-option=--mpi
+    pip install lightgbm==${lightgbm_version} --install-option=--mpi
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/linux_cuda_build.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_cuda_build.dockerfile
@@ -1,5 +1,10 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04
-LABEL lightgbmbenchmark.linux.cuda.build.version="3.2.1/20211029.1"
+LABEL lightgbmbenchmark.linux.cuda.build.version="3.2.1/20211108.1"
+
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.2.1"
 
 #################################################################################################################
 #           Global Path Setting
@@ -50,7 +55,7 @@ RUN mkdir -p /etc/OpenCL/vendors && \
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout tags/v3.2.1
+    git checkout tags/v${lightgbm_version}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 # see https://github.com/microsoft/LightGBM/blob/master/docker/gpu/dockerfile.gpu
@@ -79,16 +84,16 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' 
 
-# https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#install-python-interface-optional
+# Install LightGBM Python API from build
 RUN cd /LightGBM/python-package/ && \
     python setup.py install --precompile
 

--- a/docker/lightgbm-v3.2.1/linux_gpu_build.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_gpu_build.dockerfile
@@ -1,5 +1,10 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04
-LABEL lightgbmbenchmark.linux.gpu.build.version="3.2.1/20211029.1"
+LABEL lightgbmbenchmark.linux.gpu.build.version="3.2.1/20211108.1"
+
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.2.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -20,7 +25,7 @@ RUN apt-get install --no-install-recommends git cmake build-essential libboost-d
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout tags/v3.2.1
+    git checkout tags/v${lightgbm_version}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 RUN cd /LightGBM && \
@@ -35,16 +40,16 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' 
 
-# https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#install-python-interface-optional
+# Install LightGBM Python API from build
 RUN cd /LightGBM/python-package/ && \
     python setup.py install --precompile
 

--- a/docker/lightgbm-v3.2.1/linux_gpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/linux_gpu_pip.dockerfile
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.1-cudnn7-ubuntu18.04
-LABEL lightgbmbenchmark.linux.gpu.pip.version="3.2.1/20211029.1"
+LABEL lightgbmbenchmark.linux.gpu.pip.version="3.2.1/20211108.1"
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.2.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -23,16 +27,16 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==3.2.1' --install-option=--gpu
+    pip install lightgbm==${lightgbm_version} --install-option=--gpu
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
@@ -24,4 +24,4 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                lightgbm==${lightgbm_version}
+                lightgbm==$($Env:lightgbm_version)

--- a/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
@@ -24,7 +24,7 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                'lightgbm==${lightgbm_version}'
+                lightgbm==${lightgbm_version}
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/azureml/windows-servercore-1809:latest
-LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.2.1/20211103.1"
+LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.2.1/20211108.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -15,10 +15,10 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'lightgbm==3.2.1'
 
 # This is needed for mpi to locate libpython

--- a/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/azureml/windows-servercore-1809:latest
 LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.2.1/20211108.1"
 
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.2.1"
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
 # Create conda environment
@@ -19,8 +24,7 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                'lightgbm==3.2.1'
+                'lightgbm==${lightgbm_version}'
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
-

--- a/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
@@ -25,6 +25,3 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
                 lightgbm==${lightgbm_version}
-
-# This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
@@ -1,5 +1,11 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20211012.v1
-LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.3.0/20211029.1"
+LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.3.0/20211108.1"
+
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_branch=tags/v3.3.0
+ARG lightgbm_benchmark_branch=main
 
 RUN apt-get update && \
     apt-get -y install build-essential cmake
@@ -9,7 +15,7 @@ RUN apt-get update && \
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout tags/v3.3.0
+    git checkout ${lightgbm_branch}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 RUN cd /LightGBM && \
@@ -22,7 +28,9 @@ RUN cd /LightGBM && \
 ENV PATH /LightGBM:$PATH
 
 # building lightgbm-benchmark binaries
-RUN git clone --recursive https://github.com/microsoft/lightgbm-benchmark.git
+RUN git clone --recursive https://github.com/microsoft/lightgbm-benchmark.git && \
+    cd lightgbm-benchmark && \
+    git checkout ${lightgbm_benchmark_branch}
 
 # assuming lightgbm lib+includes are installed on the system
 RUN cd /lightgbm-benchmark/src/binaries/ && \

--- a/docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
+++ b/docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
@@ -4,7 +4,7 @@ LABEL lightgbmbenchmark.linux.cpu.mpi.build.version="3.3.0/20211108.1"
 # Those arguments will NOT be used by AzureML
 # they are here just to allow for lightgbm-benchmark build to actually check
 # dockerfiles in a PR against their actual branch
-ARG lightgbm_branch=tags/v3.3.0
+ARG lightgbm_version="3.3.0"
 ARG lightgbm_benchmark_branch=main
 
 RUN apt-get update && \
@@ -15,7 +15,7 @@ RUN apt-get update && \
 # Clone lightgbm official repository (master branch)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
     cd LightGBM && \
-    git checkout ${lightgbm_branch}
+    git checkout tags/v${lightgbm_version}
 
 # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
 RUN cd /LightGBM && \
@@ -69,6 +69,9 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0'
 
-# https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#install-python-interface-optional
+# Install LightGBM Python API from build
 RUN cd /LightGBM/python-package/ && \
     python setup.py install --precompile
+
+# This is needed for mpi to locate libpython
+ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
@@ -30,7 +30,7 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==${lightgbm_version}' --install-option=--mpi
+    pip install lightgbm==${lightgbm_version} --install-option=--mpi
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
 LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211108.1"
 
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.3.0"
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
 # Create conda environment
@@ -25,7 +30,7 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
 # install lightgbm with mpi
 RUN pip install --upgrade pip setuptools wheel && \
     pip install 'cmake==3.21.0' && \
-    pip install 'lightgbm==3.3.0' --install-option=--mpi
+    pip install 'lightgbm==${lightgbm_version}' --install-option=--mpi
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
-LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211029.1"
+LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211108.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -16,10 +16,10 @@ RUN HOROVOD_WITH_TENSORFLOW=1 \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'mpi4py==3.1.1'
 
 # install lightgbm with mpi

--- a/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
@@ -24,4 +24,4 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                lightgbm==${lightgbm_version}
+                lightgbm==$($Env:lightgbm_version)

--- a/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
@@ -24,7 +24,7 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                'lightgbm==${lightgbm_version}'
+                lightgbm==${lightgbm_version}
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/azureml/windows-servercore-1809:latest
 LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.3.0/20211108.1"
 
+# Those arguments will NOT be used by AzureML
+# they are here just to allow for lightgbm-benchmark build to actually check
+# dockerfiles in a PR against their actual branch
+ARG lightgbm_version="3.3.0"
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
 # Create conda environment
@@ -19,8 +24,7 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-defaults==1.35.0' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
-                'lightgbm==3.3.0'
+                'lightgbm==${lightgbm_version}'
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
-

--- a/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/azureml/windows-servercore-1809:latest
-LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.3.0/20211103.1"
+LABEL lightgbmbenchmark.windows.cpu.mpi.pip.version="3.3.0/20211108.1"
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/lightgbm
 
@@ -15,10 +15,10 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'numpy>=1.10,<1.20' \
                 'scipy~=1.5.0' \
                 'scikit-learn~=0.24.1' \
-                'azureml-core==1.30.0' \
-                'azureml-defaults==1.30.0' \
-                'azureml-mlflow==1.30.0' \
-                'azureml-telemetry==1.30.0' \
+                'azureml-core==1.35.0' \
+                'azureml-defaults==1.35.0' \
+                'azureml-mlflow==1.35.0' \
+                'azureml-telemetry==1.35.0' \
                 'lightgbm==3.3.0'
 
 # This is needed for mpi to locate libpython

--- a/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+++ b/docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
@@ -25,6 +25,3 @@ RUN pip install 'pandas>=1.1,<1.2' \
                 'azureml-mlflow==1.35.0' \
                 'azureml-telemetry==1.35.0' \
                 lightgbm==${lightgbm_version}
-
-# This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
- in docker build, use ARG to make sure we're building from the github branch of the PR (we didn't do that before, so we actually only built from main branch)
- standardize ARG for every dockerfile