### PR TITLE
Fix exceptions that occured when parsing libsvm input files in lightgbm_predict binary on Linux

### DIFF
--- a/src/binaries/lightgbm_predict/main.cc
+++ b/src/binaries/lightgbm_predict/main.cc
@@ -79,9 +79,9 @@ class LightGBMDataReader {
             try {
 #ifdef USE_LIGHTGBM_V321_PARSER
             // LightGBM::Parser <3.2.1 uses 4 arguments, not 5
-                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0);
+                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, 0, 0);
 #else
-                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0, false);
+                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, 0, 0, false);
 #endif
             } catch (...) {
                 cerr << "Failed during Parser::CreateParser() call";

--- a/src/binaries/lightgbm_predict/main.cc
+++ b/src/binaries/lightgbm_predict/main.cc
@@ -168,6 +168,19 @@ class LightGBMDataReader {
             bool fetched_parsable_line = false;
             do {
                 if(getline(*this->file_handler, input_line)) {
+                    if (!input_line.empty() && input_line.back() == '\n')
+                    {
+                        input_line.pop_back();
+                    }
+                    if (!input_line.empty() && input_line.back() == '\r')
+                    {
+                        input_line.pop_back();
+                    }
+                    if (input_line.empty())
+                    {
+                        cout << "Empty line" << endl;
+                        return nullptr;
+                    }
                     this->row_counter++;
                     cout << "ROW line=" << this->row_counter;
                 } else {

--- a/src/binaries/lightgbm_predict/main.cc
+++ b/src/binaries/lightgbm_predict/main.cc
@@ -76,12 +76,18 @@ class LightGBMDataReader {
         // open the file for parsing
         int open(const string file_path, int32_t num_features) {
             // use Parser class from LightGBM source code
+            try {
 #ifdef USE_LIGHTGBM_V321_PARSER
             // LightGBM::Parser <3.2.1 uses 4 arguments, not 5
-            this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0);
+                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0);
 #else
-            this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0, false);
+                this->lightgbm_parser = Parser::CreateParser(file_path.c_str(), false, num_features, 0, false);
 #endif
+            } catch (...) {
+                cerr << "Failed during Parser::CreateParser() call"
+                throw;
+            }
+
             if (this->lightgbm_parser == nullptr) {
                 throw std::runtime_error("Could not recognize data format");
             }
@@ -171,7 +177,12 @@ class LightGBMDataReader {
             csr_row->row_headers[0] = 0; // memory index begin of row (0, duh)
 
             oneline_features.clear();
-            this->lightgbm_parser->ParseOneLine(input_line.c_str(), &oneline_features, &row_label);
+            try {
+                this->lightgbm_parser->ParseOneLine(input_line.c_str(), &oneline_features, &row_label);
+            } catch (...) {
+                cout << " FAIL";
+                return nullptr;
+            }
 
             cout << " label=" << row_label;
 


### PR DESCRIPTION
Running on libsvm files on local/windows VM was working perfectly. But on Linux in AzureML was failing due to the fatal error here: ["Log::Fatal("Input format error when parsing as LibSVM")"](https://github.com/microsoft/LightGBM/blob/3b6ebd794b82e02f8d5e1d0b915533bb4c36dbfc/src/io/parser.hpp#L118).

Turns out, the process for parsing libsvm files and use LibSVMParser.ParseOneLine() was failing in Linux (and not on my local tests on Windows) because the trimming behavior of getline() is different between GCC and MSVC. This PR resolves that by trimming lines ourselves.