### PR TITLE
Fix path to custom docker containers for LightGBM training pipeline

### DIFF
--- a/pipelines/azureml/conf/experiments/lightgbm_training/cpu-custom.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/cpu-custom.yaml
@@ -67,4 +67,4 @@ lightgbm_training:
     device_type: "cpu"
     nodes: 1
     processes: 1
-    override_docker: "dockers/lightgbm_cpu_mpi_custom.dockerfile" # relative to lightgbm_python folder
+    override_docker: "docker/lightgbm-custom/v330_patch_cpu_mpi_build.dockerfile" # relative to lightgbm_python folder

--- a/pipelines/azureml/conf/experiments/lightgbm_training/gpu.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/gpu.yaml
@@ -67,4 +67,4 @@ lightgbm_training:
     device_type: "gpu"
     nodes: 1
     processes: 1
-    override_docker: "dockers/lightgbm_gpu_pip.dockerfile" # relative to lightgbm_python folder
+    override_docker: "docker/lightgbm-v3.3.0/linux_gpu_pip.dockerfile" # relative to lightgbm_python folder

--- a/pipelines/azureml/conf/experiments/lightgbm_training/sweep.yaml
+++ b/pipelines/azureml/conf/experiments/lightgbm_training/sweep.yaml
@@ -69,7 +69,7 @@ lightgbm_training:
     device_type: "cpu"
     nodes: 1
     processes: 1
-    #override_docker: "dockers/lightgbm_cpu_mpi_pip.dockerfile" # relative to lightgbm_python folder
+    #override_docker: "docker/lightgbm-custom/v330_patch_cpu_mpi_build.dockerfile" # relative to lightgbm_python folder
 
     # SWEEP
     sweep_algorithm: "random"

--- a/pipelines/azureml/pipelines/lightgbm_training.py
+++ b/pipelines/azureml/pipelines/lightgbm_training.py
@@ -17,10 +17,11 @@ from shrike.pipeline.pipeline_helper import AMLPipelineHelper
 from azure.ml.component.environment import Docker
 
 # when running this script directly, needed to import common
-LIGHTGBM_BENCHMARK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'src'))
+LIGHTGBM_BENCHMARK_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 if LIGHTGBM_BENCHMARK_ROOT not in sys.path:
-    sys.path.append(str(LIGHTGBM_BENCHMARK_ROOT))
+    print(f"Adding {LIGHTGBM_BENCHMARK_ROOT}/src/ to path")
+    sys.path.append(str(os.path.join(LIGHTGBM_BENCHMARK_ROOT, "src")))
 
 from common.sweep import SweepParameterParser
 from common.tasks import training_task, training_variant
@@ -379,7 +380,7 @@ class LightGBMTraining(AMLPipelineHelper):
 
                 # optional: override environment (ex: to test custom builds)
                 if 'override_docker' in runsettings and runsettings['override_docker']:
-                    custom_docker = Docker(file=os.path.join(config.module_loader.local_steps_folder, "lightgbm_python", runsettings['override_docker']))
+                    custom_docker = Docker(file=os.path.join(LIGHTGBM_BENCHMARK_ROOT, runsettings['override_docker']))
                     lightgbm_train_step.runsettings.environment.configure(
                         docker=custom_docker,
                         os=runsettings.get('override_os', 'Linux')


### PR DESCRIPTION
The lightgbm training pipeline wasn't updated with the latest path to the dockers (that change was made in inferencing pipeline, but not propagated to training). This PR fixes that.