### PR TITLE
Update to treelite 2.1.0, and other dependencies updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest==6.2.4
 pytest-cov==2.12.1
 pytest-mock==3.6.1
 mlflow==1.21.0
-shrike[pipeline]==1.12.2
+shrike[pipeline]==1.11.10
 hydra-core==1.0.7
 omegaconf==2.0.6
 treelite==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-lightgbm==3.2.1
+lightgbm==3.3.0
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-mock==3.6.1
-mlflow==1.19.0
-shrike[pipeline]==1.11.10
+mlflow==1.21.0
+shrike[pipeline]==1.12.2
 hydra-core==1.0.7
 omegaconf==2.0.6
-treelite==1.3.0
-treelite_runtime==1.3.0
+treelite==2.1.0
+treelite_runtime==2.1.0
 mpi4py==3.1.1
 matplotlib==3.4.3

--- a/src/scripts/inferencing/treelite_python/conda_env.yaml
+++ b/src/scripts/inferencing/treelite_python/conda_env.yaml
@@ -11,4 +11,3 @@ dependencies:
   - treelite_runtime==2.1.0
   - pandas>=1.1,<1.2
   - numpy>=1.10,<1.20
-  

--- a/src/scripts/inferencing/treelite_python/conda_env.yaml
+++ b/src/scripts/inferencing/treelite_python/conda_env.yaml
@@ -9,4 +9,6 @@ dependencies:
   - azureml-mlflow==1.35.0
   - treelite==2.1.0
   - treelite_runtime==2.1.0
-
+  - pandas>=1.1,<1.2
+  - numpy>=1.10,<1.20
+  

--- a/src/scripts/inferencing/treelite_python/conda_env.yaml
+++ b/src/scripts/inferencing/treelite_python/conda_env.yaml
@@ -5,7 +5,8 @@ dependencies:
 - python=3.8
 - pip=20.0
 - pip:
-  - azureml-defaults==1.30.0
-  - azureml-mlflow==1.30.0
-  - treelite==1.3.0
-  - treelite_runtime==1.3.0
+  - azureml-defaults==1.35.0
+  - azureml-mlflow==1.35.0
+  - treelite==2.1.0
+  - treelite_runtime==2.1.0
+

--- a/src/scripts/model_transformation/treelite_compile/conda_env.yaml
+++ b/src/scripts/model_transformation/treelite_compile/conda_env.yaml
@@ -5,7 +5,7 @@ dependencies:
 - python=3.8
 - pip=20.0
 - pip:
-  - azureml-defaults==1.30.0
-  - azureml-mlflow==1.30.0
-  - treelite==1.3.0
-  - treelite_runtime==1.3.0
+  - azureml-defaults==1.35.0
+  - azureml-mlflow==1.35.0
+  - treelite==2.1.0
+  - treelite_runtime==2.1.0

--- a/src/scripts/model_transformation/treelite_compile/conda_env.yaml
+++ b/src/scripts/model_transformation/treelite_compile/conda_env.yaml
@@ -11,4 +11,3 @@ dependencies:
   - treelite_runtime==2.1.0
   - pandas>=1.1,<1.2
   - numpy>=1.10,<1.20
-  

--- a/src/scripts/model_transformation/treelite_compile/conda_env.yaml
+++ b/src/scripts/model_transformation/treelite_compile/conda_env.yaml
@@ -9,3 +9,6 @@ dependencies:
   - azureml-mlflow==1.35.0
   - treelite==2.1.0
   - treelite_runtime==2.1.0
+  - pandas>=1.1,<1.2
+  - numpy>=1.10,<1.20
+  


### PR DESCRIPTION
Update dependencies to use treelite 2.1.0 instead of 1.3.0