### PR TITLE
Add predictions output to LightGBM python

### DIFF
--- a/src/scripts/inferencing/lightgbm_python/score.py
+++ b/src/scripts/inferencing/lightgbm_python/score.py
@@ -105,10 +105,23 @@ class LightGBMPythonInferecingScript(RunnableScript):
 
         logger.info(f"Running .predict()")
         with metrics_logger.log_time_block("time_inferencing"):
-            booster.predict(
+            predictions_array = booster.predict(
                 data=inference_raw_data,
                 num_threads=args.num_threads,
                 predict_disable_shape_check=bool(args.predict_disable_shape_check)
+            )
+        
+        if args.output:
+            numpy.savetxt(
+                args.output,
+                predictions_array,
+                fmt='%f',
+                delimiter=',',
+                newline='\n',
+                header='',
+                footer='',
+                comments='# ',
+                encoding=None
             )
 
 

--- a/tests/scripts/test_lightgbm_python.py
+++ b/tests/scripts/test_lightgbm_python.py
@@ -65,4 +65,4 @@ def test_lightgbm_python_score(temporary_dir, regression_model_sample, regressio
         score.main()
 
     # test expected outputs
-    #assert os.path.isfile(os.path.join(predictions_dir, "predictions.txt"))
+    assert os.path.isfile(os.path.join(predictions_dir, "predictions.txt"))


### PR DESCRIPTION
We need to check if the outputs from lightgbm are consistent accross variants. This will output the predictions.