### PR TITLE
Fix conda dependencies to add common required package psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ treelite==2.1.0
 treelite_runtime==2.1.0
 mpi4py==3.1.1
 matplotlib==3.4.3
+psutil==5.8.0

--- a/src/scripts/data_processing/generate_data/conda_env.yaml
+++ b/src/scripts/data_processing/generate_data/conda_env.yaml
@@ -7,5 +7,6 @@ dependencies:
 - pip:
   - numpy==1.21.2
   - scikit-learn==0.24.2
-  - azureml-defaults==1.30.0
-  - azureml-mlflow==1.30.0
+  - azureml-defaults==1.35.0
+  - azureml-mlflow==1.35.0
+  - psutil==5.8.0

--- a/src/scripts/data_processing/lightgbm_data2bin/conda_env.yml
+++ b/src/scripts/data_processing/lightgbm_data2bin/conda_env.yml
@@ -7,6 +7,7 @@ dependencies:
 - pip:
   - numpy==1.21.2
   - scikit-learn==0.24.2
-  - azureml-defaults==1.30.0
-  - azureml-mlflow==1.30.0
+  - azureml-defaults==1.35.0
+  - azureml-mlflow==1.35.0
+  - psutil==5.8.0
   - lightgbm==3.2.1

--- a/src/scripts/data_processing/partition_data/conda_env.yml
+++ b/src/scripts/data_processing/partition_data/conda_env.yml
@@ -7,5 +7,7 @@ dependencies:
 - pip:
   - numpy==1.21.2
   - scikit-learn==0.24.2
-  - azureml-defaults==1.30.0
-  - azureml-mlflow==1.30.0
+  - azureml-defaults==1.35.0
+  - azureml-mlflow==1.35.0
+  - psutil==5.8.0
+

--- a/src/scripts/inferencing/treelite_python/conda_env.yaml
+++ b/src/scripts/inferencing/treelite_python/conda_env.yaml
@@ -7,6 +7,7 @@ dependencies:
 - pip:
   - azureml-defaults==1.35.0
   - azureml-mlflow==1.35.0
+  - psutil==5.8.0
   - treelite==2.1.0
   - treelite_runtime==2.1.0
   - pandas>=1.1,<1.2

--- a/src/scripts/model_transformation/treelite_compile/conda_env.yaml
+++ b/src/scripts/model_transformation/treelite_compile/conda_env.yaml
@@ -7,6 +7,7 @@ dependencies:
 - pip:
   - azureml-defaults==1.35.0
   - azureml-mlflow==1.35.0
+  - psutil==5.8.0
   - treelite==2.1.0
   - treelite_runtime==2.1.0
   - pandas>=1.1,<1.2

--- a/src/scripts/sample/conda_env.yaml
+++ b/src/scripts/sample/conda_env.yaml
@@ -7,3 +7,4 @@ dependencies:
 - pip:
   - azureml-defaults==1.35.0
   - azureml-mlflow==1.35.0
+  - psutil==5.8.0


### PR DESCRIPTION
Since we merged #178 we now use psutil in the common metrics class. This dependency was forgotten in the modules conda environments. This PR fixes that. It also updates some of those dependencies.