### PR TITLE
verify arguments of manual benchmark and align with scripts

### DIFF
--- a/docs/run/manual-benchmark.md
+++ b/docs/run/manual-benchmark.md
@@ -44,7 +44,8 @@ To generate a synthetic dataset based on sklearn:
     ```
 
 
-Note: Running the synthetic data generation script with these parameter values requires at least 4 GB of RAM available and generates a 754 MB training, a 75 MB testing, and a 744 MB inferencing dataset.
+!!! note
+    Running the synthetic data generation script with these parameter values requires at least 4 GB of RAM available and generates a 754 MB training, a 75 MB testing, and a 744 MB inferencing dataset.
 
 ## Run training on synthetic data
 
@@ -64,7 +65,8 @@ Note: Running the synthetic data generation script with these parameter values r
         --min_data_in_leaf 400 \
         --learning_rate 0.3 \
         --max_bin 16 \
-        --feature_fraction 0.15
+        --feature_fraction 0.15 \
+        --device_type cpu
     ```
 
 === "Powershell"
@@ -83,8 +85,12 @@ Note: Running the synthetic data generation script with these parameter values r
         --min_data_in_leaf 400 `
         --learning_rate 0.3 `
         --max_bin 16 `
-        --feature_fraction 0.15
+        --feature_fraction 0.15 `
+        --device_type gpu
     ```
+
+!!! note
+    `--device_type cpu` is optional here, if you're running on gpu you can use `--device_type gpu` instead.
 
 ## Run inferencing on synthetic data (lightgbm python)
 
@@ -94,7 +100,8 @@ Note: Running the synthetic data generation script with these parameter values r
     python src/scripts/inferencing/lightgbm_python/score.py \
         --data ./data/synthetic/inference/ \
         --model ./data/models/synthetic-100trees-4000cols/ \
-        --output ./data/outputs/predictions/
+        --output ./data/outputs/predictions/ \
+        --num_threads 1
     ```
 
 === "Powershell"
@@ -103,29 +110,6 @@ Note: Running the synthetic data generation script with these parameter values r
     python src/scripts/inferencing/lightgbm_python/score.py `
         --data ./data/synthetic/inference/ `
         --model ./data/models/synthetic-100trees-4000cols/ `
-        --output ./data/outputs/predictions/
-    ```
-
-## Run inferencing on synthetic data (lightgbm cli)
-
-If you have a local installation of lightgbm cli, run the `lightgbm_cli` script by pointing to the lightgbm binaries (works for both linux and windows).
-
-=== "Bash"
-
-    ```bash
-    python src/scripts/inferencing/lightgbm_cli/score.py \
-        --lightgbm_exec ./build/windows/x64/Release/lightgbm.exe \
-        --data ./data/synthetic/inference/ \
-        --model ./data/models/synthetic-100trees-4000cols/ \
-        --output ./data/outputs/predictions/
-    ```
-
-=== "Powershell"
-
-    ``` powershell
-    python src/scripts/inferencing/lightgbm_cli/score.py `
-        --lightgbm_exec ./build/windows/x64/Release/lightgbm.exe `
-        --data ./data/synthetic/inference/ `
-        --model ./data/models/synthetic-100trees-4000cols/ `
-        --output ./data/outputs/predictions/
+        --output ./data/outputs/predictions/ `
+        --num_threads 1
     ```

--- a/src/scripts/training/lightgbm_python/train.py
+++ b/src/scripts/training/lightgbm_python/train.py
@@ -114,7 +114,7 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
         group_lgbm.add_argument("--learning_rate", required=True, type=float)
         group_lgbm.add_argument("--max_bin", required=True, type=int)
         group_lgbm.add_argument("--feature_fraction", required=True, type=float)
-        group_lgbm.add_argument("--device_type", required=True, type=str)
+        group_lgbm.add_argument("--device_type", required=False, type=str, default="cpu")
         group_lgbm.add_argument("--custom_params", required=False, type=str, default=None)
 
         return parser


### PR DESCRIPTION
Verified the manual benchmark docs page and fixed the following:
- made device_type optional when running local
- explained device_type in the docs
- added num_thread as it could be relevant for lightgbm inferencing
- removed the lightgbm_cli section as we're trying to deprecate this (see #165 