### PR TITLE
Create distinct class for single node and multi node, with shared utility functions

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -22,7 +22,7 @@ class RunnableScript():
     of every script in the lightgbm-benchmark repo: logging init, MLFlow init,
     system properties logging, etc.
     """
-    def __init__(self, task, framework, framework_version, metrics_prefix=None, do_not_log_properties=False):
+    def __init__(self, task, framework, framework_version, metrics_prefix=None):
         """ Generic initialization for all script classes.
 
         Args:
@@ -30,14 +30,11 @@ class RunnableScript():
             framework (str): name of ML framework
             framework_version (str): a version of this framework
             metrics_prefix (str): any prefix to add to this scripts metrics
-            do_not_log_properties (bool): block all calls to log_properties()
-                ex: in mpi, we want to report those only on node 0
         """
         self.task = task
         self.framework = framework
         self.framework_version = framework_version
         self.metrics_prefix = metrics_prefix
-        self.do_not_log_properties = do_not_log_properties
 
         self.logger = logging.getLogger(f"{framework}.{task}")
 
@@ -95,6 +92,27 @@ class RunnableScript():
         """
         raise NotImplementedError(f"run() method from class {self.__class__.__name__} hasn't actually been implemented.")
 
+    def initialize_run(self, args):
+        """Initialize the component run, opens/setups what needs to be"""
+        # record properties of the run
+        self.metrics_logger.set_properties(
+            task = self.task,
+            framework = self.framework,
+            framework_version = self.framework_version
+        )
+
+        # if provided some custom_properties by the outside orchestrator
+        if args.custom_properties:
+            self.metrics_logger.set_properties_from_json(args.custom_properties)
+
+        # add properties about environment of this script
+        self.metrics_logger.set_platform_properties()
+
+    def finalize_run(self, args):
+        """Finalize the run, close what needs to be"""
+        # close mlflow
+        self.metrics_logger.close()
+
     @classmethod
     def main(cls, cli_args=None):
         """ Component main function, it is not recommended to override this method.
@@ -116,30 +134,14 @@ class RunnableScript():
     
         # if argument parsing fails, or if unknown arguments, will except
         args, unknown_args = parser.parse_known_args(cli_args)
+        logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
 
         # create script instance, initialize mlflow
         script_instance = cls()
-
-        if not script_instance.do_not_log_properties:
-            script_instance.metrics_logger.set_properties(
-                task = script_instance.task,
-                framework = script_instance.framework,
-                framework_version = script_instance.framework_version
-            )
-
-        logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
-
-        # if provided some custom_properties by the outside orchestrator
-        if not script_instance.do_not_log_properties:
-            if args.custom_properties:
-                script_instance.metrics_logger.set_properties_from_json(args.custom_properties)
-
-        # add properties about environment of this script
-        if not script_instance.do_not_log_properties:
-            script_instance.metrics_logger.set_platform_properties()
+        script_instance.initialize_run(args)
 
         # run the actual thing
         script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
 
         # close mlflow
-        script_instance.metrics_logger.close()
+        script_instance.finalize_run()

--- a/src/common/components.py
+++ b/src/common/components.py
@@ -94,6 +94,8 @@ class RunnableScript():
 
     def initialize_run(self, args):
         """Initialize the component run, opens/setups what needs to be"""
+        self.logger.info("Initializing script run...")
+
         # record properties of the run
         self.metrics_logger.set_properties(
             task = self.task,
@@ -110,6 +112,8 @@ class RunnableScript():
 
     def finalize_run(self, args):
         """Finalize the run, close what needs to be"""
+        self.logger.info("Finalizing script run...")
+
         # close mlflow
         self.metrics_logger.close()
 
@@ -144,4 +148,4 @@ class RunnableScript():
         script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
 
         # close mlflow
-        script_instance.finalize_run()
+        script_instance.finalize_run(args)

--- a/src/common/components.py
+++ b/src/common/components.py
@@ -80,18 +80,6 @@ class RunnableScript():
 
         return parser
 
-    def run(self, args, logger, metrics_logger, unknown_args):
-        """The run function of your script. You are required to override this method
-        with your own implementation.
-
-        Args:
-            args (argparse.namespace): command line arguments provided to script
-            logger (logging.logger): a logger initialized for this script
-            metrics_logger (common.metrics.MetricLogger): to report metrics for this script, already initialized for MLFlow
-            unknown_args (list[str]): list of arguments not recognized during argparse
-        """
-        raise NotImplementedError(f"run() method from class {self.__class__.__name__} hasn't actually been implemented.")
-
     def initialize_run(self, args):
         """Initialize the component run, opens/setups what needs to be"""
         self.logger.info("Initializing script run...")
@@ -109,6 +97,18 @@ class RunnableScript():
 
         # add properties about environment of this script
         self.metrics_logger.set_platform_properties()
+
+    def run(self, args, logger, metrics_logger, unknown_args):
+        """The run function of your script. You are required to override this method
+        with your own implementation.
+
+        Args:
+            args (argparse.namespace): command line arguments provided to script
+            logger (logging.logger): a logger initialized for this script
+            metrics_logger (common.metrics.MetricLogger): to report metrics for this script, already initialized for MLFlow
+            unknown_args (list[str]): list of arguments not recognized during argparse
+        """
+        raise NotImplementedError(f"run() method from class {self.__class__.__name__} hasn't actually been implemented.")
 
     def finalize_run(self, args):
         """Finalize the run, close what needs to be"""
@@ -149,3 +149,6 @@ class RunnableScript():
 
         # close mlflow
         script_instance.finalize_run(args)
+
+class SingleNodeScript(RunnableScript):
+    pass

--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+LightGBM/Python training script
+"""
+import os
+import sys
+import argparse
+import logging
+import traceback
+import json
+from mpi4py import MPI
+from .components import RunnableScript
+from collections import namedtuple
+
+def detect_mpi_config():
+    """ Detects if we're running in MPI.
+    Args:
+        None
+
+    Returns:
+        mpi_config (namedtuple)
+    """
+    # check if we're running multi or single node
+    mpi_config_tuple = namedtuple("mpi_config", ['world_size', 'world_rank', 'mpi_available', 'main_node'])
+
+    try:
+        comm = MPI.COMM_WORLD
+        mpi_config = mpi_config_tuple(
+            comm.Get_size(), # world_size
+            comm.Get_rank(), # world_rank
+            (comm.Get_size() > 1), # mpi_available
+            (comm.Get_rank() == 0), # main_node
+        )
+        logging.getLogger().info(f"MPI detection results: {mpi_config}")
+    except:
+        mpi_config = mpi_config_tuple(
+            1, # world_size
+            0, # world_rank
+            False, # mpi_available
+            True, # main_node
+        )
+        logging.getLogger().critical(f"MPI detection failed, switching to single node: {mpi_config}, see traceback below:\n{traceback.format_exc()}")
+
+    return mpi_config
+
+class MultiNodeScript(RunnableScript):
+    def __init__(self, task, framework, framework_version, metrics_prefix=None):
+        """ Generic initialization for all script classes.
+
+        Args:
+            task (str): name of task in the pipeline/benchmark (ex: train, score)
+            framework (str): name of ML framework
+            framework_version (str): a version of this framework
+            metrics_prefix (str): any prefix to add to this scripts metrics
+        """
+        # just use the regular init
+        super().__init__(
+            task = task,
+            framework = framework,
+            framework_version = framework_version,
+            metrics_prefix = metrics_prefix
+        )
+
+        # but also add mpi_config
+        self._mpi_config = detect_mpi_config()
+
+    def mpi_config(self):
+        """Getter method"""
+        return self._mpi_config
+
+    def initialize_run(self, args):
+        """Initialize the component run, opens/setups what needs to be"""
+        self.logger.info("Initializing multi node component script...")
+        if self._mpi_config.main_node:
+            # record properties only from the main node
+            self.metrics_logger.set_properties(
+                task = self.task,
+                framework = self.framework,
+                framework_version = self.framework_version
+            )
+
+            # if provided some custom_properties by the outside orchestrator
+            if args.custom_properties:
+                self.metrics_logger.set_properties_from_json(args.custom_properties)
+
+            # add properties about environment of this script
+            self.metrics_logger.set_platform_properties()
+
+    def finalize_run(self, args):
+        """Finalize the run, close what needs to be"""
+        self.logger.info("Finalizing multi node component script...")
+        # clean exit from mpi
+        if MPI.Is_initialized():
+            self.logger.info("MPI was initialized, calling MPI.finalize()")
+            MPI.Finalize()
+        
+        # then use the super finalization method
+        super().finalize_run(args)

--- a/src/scripts/training/lightgbm_python/train.py
+++ b/src/scripts/training/lightgbm_python/train.py
@@ -26,7 +26,7 @@ if COMMON_ROOT not in sys.path:
 from common.components import RunnableScript
 from common.io import get_all_files
 from common.lightgbm_utils import LightGBMCallbackHandler
-from common.mpi import MultiNodeScript
+from common.distributed import MultiNodeScript
 
 class LightGBMPythonMpiTrainingScript(MultiNodeScript):
     def __init__(self):

--- a/src/scripts/training/lightgbm_python/train.py
+++ b/src/scripts/training/lightgbm_python/train.py
@@ -12,7 +12,6 @@ import traceback
 import json
 from distutils.util import strtobool
 import lightgbm
-from mpi4py import MPI
 from collections import namedtuple
 
 # Add the right path to PYTHONPATH
@@ -27,46 +26,14 @@ if COMMON_ROOT not in sys.path:
 from common.components import RunnableScript
 from common.io import get_all_files
 from common.lightgbm_utils import LightGBMCallbackHandler
+from common.mpi import MultiNodeScript
 
-def detect_mpi_config():
-    """ Detects if we're running in MPI.
-    Args:
-        None
-
-    Returns:
-        mpi_config (namedtuple)
-    """
-    # check if we're running multi or single node
-    mpi_config_tuple = namedtuple("mpi_config", ['world_size', 'world_rank', 'mpi_available', 'main_node'])
-
-    try:
-        comm = MPI.COMM_WORLD
-        mpi_config = mpi_config_tuple(
-            comm.Get_size(), # world_size
-            comm.Get_rank(), # world_rank
-            (comm.Get_size() > 1), # mpi_available
-            (comm.Get_rank() == 0), # main_node
-        )
-        logging.getLogger().info(f"MPI detection results: {mpi_config}")
-    except:
-        mpi_config = mpi_config_tuple(
-            1, # world_size
-            0, # world_rank
-            False, # mpi_available
-            True, # main_node
-        )
-        logging.getLogger().critical(f"MPI detection failed, switching to single node: {mpi_config}, see traceback below:\n{traceback.format_exc()}")
-
-    return mpi_config
-
-class LightGBMPythonMpiTrainingScript(RunnableScript):
+class LightGBMPythonMpiTrainingScript(MultiNodeScript):
     def __init__(self):
-        self.mpi_config = detect_mpi_config()
         super().__init__(
             task = "train",
             framework = "lightgbm",
-            framework_version = lightgbm.__version__,
-            do_not_log_properties=not(self.mpi_config.main_node)
+            framework_version = lightgbm.__version__
         )
 
     @classmethod
@@ -209,22 +176,25 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
             metrics_logger (common.metrics.MetricLogger)
             unknown_args (list[str]): list of arguments not recognized during argparse
         """
+        # get mpi config as a namedtuple
+        mpi_config = self.mpi_config()
+
         # figure out the lgbm params from cli args + mpi config
-        lgbm_params = self.load_lgbm_params_from_cli(args, self.mpi_config)
+        lgbm_params = self.load_lgbm_params_from_cli(args, mpi_config)
 
         # create a handler for the metrics callbacks
         callbacks_handler = LightGBMCallbackHandler(
             metrics_logger=metrics_logger,
-            metrics_prefix=f"node_{self.mpi_config.world_rank}/"
+            metrics_prefix=f"node_{mpi_config.world_rank}/"
         )
 
         # make sure the output argument exists
-        if args.export_model and self.mpi_config.main_node:
+        if args.export_model and mpi_config.main_node:
             os.makedirs(args.export_model, exist_ok=True)
             args.export_model = os.path.join(args.export_model, "model.txt")
 
         # log params only once by doing it only on main node (node 0)
-        if self.mpi_config.main_node:
+        if mpi_config.main_node:
             # log lgbm parameters
             logger.info(f"LGBM Params: {lgbm_params}")
             metrics_logger.log_parameters(**lgbm_params)
@@ -233,9 +203,9 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
         lightgbm.register_logger(logger)
 
         logger.info(f"Loading data for training")
-        with metrics_logger.log_time_block("time_data_loading", step=self.mpi_config.world_rank):
+        with metrics_logger.log_time_block("time_data_loading", step=mpi_config.world_rank):
             # obtain the path to the train data for this node
-            train_data_path = self.assign_train_data(args, self.mpi_config)
+            train_data_path = self.assign_train_data(args, mpi_config)
             test_data_paths = get_all_files(args.test)
 
             logger.info(f"Running with 1 train file and {len(test_data_paths)} test files.")
@@ -247,8 +217,8 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
                     train_data.create_valid(test_data_path).construct() for test_data_path in test_data_paths
                 ]
                 # capture data shape in metrics
-                metrics_logger.log_metric(key="train_data.length", value=train_data.num_data(), step=self.mpi_config.world_rank)
-                metrics_logger.log_metric(key="train_data.width", value=train_data.num_feature(), step=self.mpi_config.world_rank)
+                metrics_logger.log_metric(key="train_data.length", value=train_data.num_data(), step=mpi_config.world_rank)
+                metrics_logger.log_metric(key="train_data.width", value=train_data.num_feature(), step=mpi_config.world_rank)
             else:
                 train_data = lightgbm.Dataset(train_data_path, params=lgbm_params)
                 val_datasets = [
@@ -260,7 +230,7 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
                 # metrics_logger.log_metric(key="train_data.width", value="n/a")
 
         logger.info(f"Training LightGBM with parameters: {lgbm_params}")
-        with metrics_logger.log_time_block("time_training", step=self.mpi_config.world_rank):
+        with metrics_logger.log_time_block("time_training", step=mpi_config.world_rank):
             booster = lightgbm.train(
                 lgbm_params,
                 train_data,
@@ -268,14 +238,9 @@ class LightGBMPythonMpiTrainingScript(RunnableScript):
                 callbacks=[callbacks_handler.callback]
             )
 
-        if args.export_model and self.mpi_config.main_node:
+        if args.export_model and mpi_config.main_node:
             logger.info(f"Writing model in {args.export_model}")
             booster.save_model(args.export_model)
-
-        # clean exit from mpi
-        if MPI.Is_initialized():
-            logger.info("MPI was initialized, calling MPI.finalize()")
-            MPI.Finalize()
 
 
 def get_arg_parser(parser=None):


### PR DESCRIPTION
This PR introduces a new component class `MultiNodeScript` that is distinct from `RunnableScript`.

Initially, every component was using `RunnableScript`, but for distributed we needed to bypass some of the initializing code (you want to log properties only on head node, etc), using a flag. This is confusing, and also we're already thinking of adding extensions to the distributed lightgbm training (like performance metrics #71 ) which will require even more differences between single node and multi node.

Introducing this new class makes developer code simpler (just import the right class), and refactors some common routines.