### PR TITLE
Create performance reporting thread for single node components

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -15,7 +15,6 @@ import traceback
 from distutils.util import strtobool
 
 from .metrics import MetricsLogger
-from .perf import PerformanceReportingThread
 
 class RunnableScript():
     """
@@ -121,15 +120,6 @@ class RunnableScript():
         # create script instance, initialize mlflow
         script_instance = cls()
 
-        # start perf measurement
-        perf_report_thread = PerformanceReportingThread(
-            metrics_logger=script_instance.metrics_logger,
-            store_max_length=1000,
-            initial_time_increment=1,
-            report_each_step=True,
-            report_at_finalize=True
-        )
-
         if not script_instance.do_not_log_properties:
             script_instance.metrics_logger.set_properties(
                 task = script_instance.task,
@@ -150,9 +140,6 @@ class RunnableScript():
 
         # run the actual thing
         script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
-
-        # close perf reporting
-        perf_report_thread.finalize()
 
         # close mlflow
         script_instance.metrics_logger.close()

--- a/src/common/perf.py
+++ b/src/common/perf.py
@@ -1,0 +1,247 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Helps with reporting performance metrics (cpu/mem utilization)
+"""
+import logging
+import threading
+import time
+import psutil
+import matplotlib.pyplot as plt
+
+class PerformanceReportingThread(threading.Thread):
+    """Thread to report performance (cpu/mem/net)"""
+    def __init__(self, metrics_logger=None, store_max_length=10000, initial_time_increment=1.0, report_each_step=False, report_at_finalize=True, world_rank=0):
+        """Constructor
+
+        Args:
+            metrics_logger (common.metrics.MetricsLogger): class to log metrics using MLFlow
+        """
+        threading.Thread.__init__(self)
+        self.killed = False # flag, set to True to kill from the inside
+
+        self.logger = logging.getLogger(__name__)
+        self.metrics_logger = metrics_logger
+
+        self.report_store = []
+        self.report_store_max_length = (store_max_length//2 + store_max_length%2) * 2 # needs to be dividable by 2
+        self.time_increment = initial_time_increment
+
+        self.report_each_step = report_each_step
+        self.report_at_finalize = report_at_finalize
+
+        self.world_rank = 0 # for mpi
+
+        plt.switch_backend('agg')
+
+
+    #####################
+    ### RUN FUNCTIONS ###
+    #####################
+
+    def store_report(self, report):
+        self.report_store.append((time.time(), report))
+
+        if len(self.report_store) >= self.report_store_max_length:
+            # trim the report by half
+            self.report_store = [
+                self.report_store[i]
+                for i in range(0, self.report_store_max_length, 2)
+            ]
+            self.time_increment *= 2
+            self.logger.warning(f"Perf report store reached max, increasing time_increment to {self.time_increment}")
+
+    def run(self):
+        """Run function"""
+        while not(self.killed):
+            if self.time_increment >= 1.0: # cpu_percent.interval already consumes 1sec
+                time.sleep(self.time_increment - 1.0) # will double every time report_store_max_length is reached
+
+            perf_report = {}
+
+            # CPU UTILIZATION
+            cpu_utilization = psutil.cpu_percent(interval=1.0, percpu=True) # will take 1 sec to return
+            perf_report["cpu_pct_per_cpu_avg"] = sum(cpu_utilization) / len(cpu_utilization)
+            perf_report["cpu_pct_per_cpu_min"] = min(cpu_utilization)
+            perf_report["cpu_pct_per_cpu_max"] = max(cpu_utilization)
+
+            # MEM UTILIZATION
+            perf_report["mem_percent"] = psutil.virtual_memory().percent
+
+            # DISK UTILIZAITON
+            perf_report["disk_usage_percent"] = psutil.disk_usage('/').percent
+            perf_report["disk_io_read_mb"] = (psutil.disk_io_counters(perdisk=False).read_bytes / (1024 * 1024))
+            perf_report["disk_io_write_mb"] = (psutil.disk_io_counters(perdisk=False).write_count / (1024 * 1024))
+
+            # NET I/O SEND/RECV
+            net_io_counters = psutil.net_io_counters(pernic=True)
+            net_io_lo_identifiers = []
+            net_io_ext_identifiers = []
+
+            for key in net_io_counters:
+                if 'loopback' in key.lower():
+                    net_io_lo_identifiers.append(key)
+                elif key.lower() == 'lo':
+                    net_io_lo_identifiers.append(key)
+                else:
+                    net_io_ext_identifiers.append(key)
+            
+            lo_sent_mb = sum(
+                [
+                    net_io_counters.get(key).bytes_sent
+                    for key in net_io_lo_identifiers
+                ]
+            ) / (1024 * 1024)
+
+            ext_sent_mb = sum(
+                [
+                    net_io_counters.get(key).bytes_sent
+                    for key in net_io_ext_identifiers
+                ]
+            ) / (1024 * 1024)
+
+            lo_recv_mb = sum(
+                [
+                    net_io_counters.get(key).bytes_recv
+                    for key in net_io_lo_identifiers
+                ]
+            ) / (1024 * 1024)
+
+            ext_recv_mb = sum(
+                [
+                    net_io_counters.get(key).bytes_recv
+                    for key in net_io_ext_identifiers
+                ]
+            ) / (1024 * 1024)
+
+            perf_report["net_io_lo_sent_mb"] = lo_sent_mb
+            perf_report["net_io_ext_sent_mb"] = ext_sent_mb
+            perf_report["net_io_lo_recv_mb"] = lo_recv_mb
+            perf_report["net_io_ext_recv_mb"] = ext_recv_mb
+
+            # END OF REPORT
+
+            if self.report_each_step:
+                self.logger.info(f"PERF={perf_report}")
+
+            self.store_report(perf_report)
+
+        if self.report_at_finalize:
+            self.plot_all_reports()
+
+    def plot_all_reports(self):
+        custom_fig_size=(8,2)
+
+        report_plots_specs = [
+            {
+                "file_key":"cpu_pct",
+                "keys":["cpu_pct_per_cpu_avg","cpu_pct_per_cpu_min","cpu_pct_per_cpu_max"],
+                "title":"CPU utilization %",
+                "xlabel":"step",
+                "ylabel":"%",
+                "bottom":0.0,
+                "top":100.0
+            },
+            {
+                "file_key":"mem_pct",
+                "keys":"mem_percent",
+                "title":"MEM utilization %",
+                "xlabel":"step",
+                "ylabel":"%",
+                "bottom":0.0,
+                "top":100.0
+            },
+            {
+                "file_key":"disk_usage",
+                "keys":"disk_usage_percent",
+                "title":"DISK usage %",
+                "xlabel":"step",
+                "ylabel":"%",
+                "bottom":0.0,
+                "top":100.0
+            },
+            {
+                "file_key":"disk_io",
+                "keys":["disk_io_read_mb", "disk_io_write_mb"],
+                "title":"DISK I/O",
+                "xlabel":"step",
+                "ylabel":"MB"
+            },
+            {
+                "file_key":"net_io",
+                "keys":["net_io_lo_sent_mb","net_io_ext_sent_mb","net_io_lo_recv_mb","net_io_ext_recv_mb"],
+                "title":"NET I/O",
+                "xlabel":"step",
+                "ylabel":"MB"
+            }
+        ]
+
+        for entry in report_plots_specs:
+            fig = plt.figure(figsize=custom_fig_size)
+            ax = fig.add_subplot(111)
+
+            # get and plot all value keys
+            if isinstance(entry["keys"], list):
+                # if multiple keys specified as lies
+                for key in entry["keys"]:
+                    # get each one distinctly
+                    values = [
+                        report.get(key, None)
+                        for report_time, report in self.report_store
+                    ]
+                    # then plot
+                    ax.plot(values, label=key)
+
+                # don't forget the legend
+                ax.legend()
+            else:
+                # if only one key
+                values = [
+                    report.get(entry["keys"], None)
+                    for report_time, report in self.report_store
+                ]
+                ax.plot(values)
+                # no legend needed here
+
+            ax.set_ylim(bottom=entry.get("bottom", None), top=entry.get("top", None))
+            ax.set_title(entry.get("title", None))
+            plt.xlabel(entry.get("xlabel", "step"))
+            plt.ylabel(entry.get("ylabel", None))
+
+            # record in mlflow
+            if self.metrics_logger:
+                self.metrics_logger.log_figure(fig, f"perf_node_{self.world_rank}_{entry['file_key']}.png")
+
+    def finalize(self):
+        self.killed = True
+        self.join()
+
+
+if __name__ == "__main__":
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    console_handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(name)s : %(message)s')
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    from metrics import MetricsLogger
+
+    metrics_logger = MetricsLogger("fake.foo")
+
+    logger.info("TEST")
+    perf_report = PerformanceReportingThread(
+        metrics_logger=metrics_logger,
+        store_max_length=10,
+        initial_time_increment=1,
+        report_each_step=True,
+        report_at_finalize=True
+    )
+    perf_report.start()
+
+    time.sleep(10)
+
+    perf_report.finalize()
+
+    metrics_logger.close()

--- a/src/common/perf.py
+++ b/src/common/perf.py
@@ -10,6 +10,7 @@ import time
 import psutil
 import matplotlib.pyplot as plt
 
+
 class PerformanceReportingThread(threading.Thread):
     """Thread to report performance (cpu/mem/net)"""
     def __init__(self, metrics_logger=None, store_max_length=10000, initial_time_increment=1.0, report_each_step=False, report_at_finalize=True, world_rank=0):
@@ -33,6 +34,7 @@ class PerformanceReportingThread(threading.Thread):
 
         self.world_rank = 0 # for mpi
 
+        # NOTE: do not use matplotlib gui backeng in a thread
         plt.switch_backend('agg')
 
 
@@ -131,7 +133,7 @@ class PerformanceReportingThread(threading.Thread):
             self.plot_all_reports()
 
     def plot_all_reports(self):
-        custom_fig_size=(8,2)
+        custom_fig_size=(16,4)
 
         report_plots_specs = [
             {
@@ -219,6 +221,7 @@ class PerformanceReportingThread(threading.Thread):
 
 
 if __name__ == "__main__":
+    # just for testing locally
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     console_handler = logging.StreamHandler()

--- a/src/common/perf.py
+++ b/src/common/perf.py
@@ -2,266 +2,122 @@
 # Licensed under the MIT license.
 
 """
-Helps with reporting performance metrics (cpu/mem utilization)
+Helps with reporting performance metrics (cpu/mem utilization).
+Needs to be implemented in the rest of the code.
 """
 import logging
 import threading
 import time
 import psutil
-import matplotlib.pyplot as plt
 
 
 class PerformanceReportingThread(threading.Thread):
     """Thread to report performance (cpu/mem/net)"""
-    def __init__(self, metrics_logger=None, store_max_length=10000, initial_time_increment=1.0, report_each_step=False, report_at_finalize=True, world_rank=0):
-        """Constructor
-
-        Args:
-            metrics_logger (common.metrics.MetricsLogger): class to log metrics using MLFlow
-            store_max_length (int): the maximum number of perf reports we want to keep for final plots
-            initial_time_increment (float): how long to wait between two perf measurements
-            report_each_step (bool): print perf measurement each step (lots!)
-            report_at_finalize (bool): plot perf measurements at the end
-            world_rank (int): in distributed, id of the node
-        """
+    def __init__(self,
+                 initial_time_increment=1.0):
+        """Constructor"""
         threading.Thread.__init__(self)
         self.killed = False # flag, set to True to kill from the inside
 
         self.logger = logging.getLogger(__name__)
-        self.metrics_logger = metrics_logger
-
-        # store all perf reports to push plots during finalization stage
-        self.report_store = []
-        self.report_store_max_length = (store_max_length//2 + store_max_length%2) * 2 # needs to be dividable by 2
 
         # time between perf reports
         self.time_increment = initial_time_increment
 
-        # flags to change behavior
-        self.report_each_step = report_each_step # will log perf at each step (lots of metrics!)
-        self.report_at_finalize = report_at_finalize # will log perf during finalization
 
-        self.world_rank = 0 # for mpi/distributed
+    ##################
+    ### CALL BACKS ###
+    ##################
 
-        # NOTE: do not use matplotlib gui backeng in a thread
-        plt.switch_backend('agg')
+    def call_on_loop(self, perf_report):
+        """You need to implement this"""
+        pass
 
+    def call_on_exit(self):
+        """You need to implement this"""
+        pass
 
     #####################
     ### RUN FUNCTIONS ###
     #####################
-
-    def store_report(self, report):
-        """Stores a perf report in internal structure.
-        Will limit the number of reports to store_max_length"""
-        self.report_store.append((time.time(), report))
-
-        if len(self.report_store) >= self.report_store_max_length:
-            # trim the report by half
-            self.report_store = [
-                self.report_store[i]
-                for i in range(0, self.report_store_max_length, 2)
-            ]
-            self.time_increment *= 2
-            self.logger.warning(f"Perf report store reached max, increasing time_increment to {self.time_increment}")
 
     def run(self):
         """Run function of the thread, while(True)"""
         while not(self.killed):
             if self.time_increment >= 1.0: # cpu_percent.interval already consumes 1sec
                 time.sleep(self.time_increment - 1.0) # will double every time report_store_max_length is reached
+            self._run_loop()
 
-            perf_report = {}
+        self.call_on_exit()
 
-            # CPU UTILIZATION
-            cpu_utilization = psutil.cpu_percent(interval=1.0, percpu=True) # will take 1 sec to return
-            perf_report["cpu_pct_per_cpu_avg"] = sum(cpu_utilization) / len(cpu_utilization)
-            perf_report["cpu_pct_per_cpu_min"] = min(cpu_utilization)
-            perf_report["cpu_pct_per_cpu_max"] = max(cpu_utilization)
+    def _run_loop(self):
+        """What to run within the while(not(killed))"""
+        perf_report = {}
 
-            # MEM UTILIZATION
-            perf_report["mem_percent"] = psutil.virtual_memory().percent
+        # CPU UTILIZATION
+        cpu_utilization = psutil.cpu_percent(interval=1.0, percpu=True) # will take 1 sec to return
+        perf_report["cpu_pct_per_cpu_avg"] = sum(cpu_utilization) / len(cpu_utilization)
+        perf_report["cpu_pct_per_cpu_min"] = min(cpu_utilization)
+        perf_report["cpu_pct_per_cpu_max"] = max(cpu_utilization)
 
-            # DISK UTILIZAITON
-            perf_report["disk_usage_percent"] = psutil.disk_usage('/').percent
-            perf_report["disk_io_read_mb"] = (psutil.disk_io_counters(perdisk=False).read_bytes / (1024 * 1024))
-            perf_report["disk_io_write_mb"] = (psutil.disk_io_counters(perdisk=False).write_count / (1024 * 1024))
+        # MEM UTILIZATION
+        perf_report["mem_percent"] = psutil.virtual_memory().percent
 
-            # NET I/O SEND/RECV
-            net_io_counters = psutil.net_io_counters(pernic=True)
-            net_io_lo_identifiers = []
-            net_io_ext_identifiers = []
+        # DISK UTILIZAITON
+        perf_report["disk_usage_percent"] = psutil.disk_usage('/').percent
+        perf_report["disk_io_read_mb"] = (psutil.disk_io_counters(perdisk=False).read_bytes / (1024 * 1024))
+        perf_report["disk_io_write_mb"] = (psutil.disk_io_counters(perdisk=False).write_count / (1024 * 1024))
 
-            for key in net_io_counters:
-                if 'loopback' in key.lower():
-                    net_io_lo_identifiers.append(key)
-                elif key.lower() == 'lo':
-                    net_io_lo_identifiers.append(key)
-                else:
-                    net_io_ext_identifiers.append(key)
-            
-            lo_sent_mb = sum(
-                [
-                    net_io_counters.get(key).bytes_sent
-                    for key in net_io_lo_identifiers
-                ]
-            ) / (1024 * 1024)
+        # NET I/O SEND/RECV
+        net_io_counters = psutil.net_io_counters(pernic=True)
+        net_io_lo_identifiers = []
+        net_io_ext_identifiers = []
 
-            ext_sent_mb = sum(
-                [
-                    net_io_counters.get(key).bytes_sent
-                    for key in net_io_ext_identifiers
-                ]
-            ) / (1024 * 1024)
-
-            lo_recv_mb = sum(
-                [
-                    net_io_counters.get(key).bytes_recv
-                    for key in net_io_lo_identifiers
-                ]
-            ) / (1024 * 1024)
-
-            ext_recv_mb = sum(
-                [
-                    net_io_counters.get(key).bytes_recv
-                    for key in net_io_ext_identifiers
-                ]
-            ) / (1024 * 1024)
-
-            perf_report["net_io_lo_sent_mb"] = lo_sent_mb
-            perf_report["net_io_ext_sent_mb"] = ext_sent_mb
-            perf_report["net_io_lo_recv_mb"] = lo_recv_mb
-            perf_report["net_io_ext_recv_mb"] = ext_recv_mb
-
-            # END OF REPORT
-
-            if self.report_each_step:
-                self.logger.info(f"PERF={perf_report}")
-
-            self.store_report(perf_report)
-
-        if self.report_at_finalize:
-            self.plot_all_reports()
-
-    def plot_all_reports(self):
-        """Use matplotlib to plot all performance reports
-        during finalization of thread"""
-        custom_fig_size=(16,4)
-
-        # define what/how to plot
-        report_plots_specs = [
-            {
-                "file_key":"cpu_pct",
-                "keys":["cpu_pct_per_cpu_avg","cpu_pct_per_cpu_min","cpu_pct_per_cpu_max"],
-                "title":"CPU utilization %",
-                "xlabel":"step",
-                "ylabel":"%",
-                "bottom":0.0,
-                "top":100.0
-            },
-            {
-                "file_key":"mem_pct",
-                "keys":"mem_percent",
-                "title":"MEM utilization %",
-                "xlabel":"step",
-                "ylabel":"%",
-                "bottom":0.0,
-                "top":100.0
-            },
-            {
-                "file_key":"disk_usage",
-                "keys":"disk_usage_percent",
-                "title":"DISK usage %",
-                "xlabel":"step",
-                "ylabel":"%",
-                "bottom":0.0,
-                "top":100.0
-            },
-            {
-                "file_key":"disk_io",
-                "keys":["disk_io_read_mb", "disk_io_write_mb"],
-                "title":"DISK I/O",
-                "xlabel":"step",
-                "ylabel":"MB"
-            },
-            {
-                "file_key":"net_io",
-                "keys":["net_io_lo_sent_mb","net_io_ext_sent_mb","net_io_lo_recv_mb","net_io_ext_recv_mb"],
-                "title":"NET I/O",
-                "xlabel":"step",
-                "ylabel":"MB"
-            }
-        ]
-
-        # loop on all plot specs and plot
-        for entry in report_plots_specs:
-            fig = plt.figure(figsize=custom_fig_size)
-            ax = fig.add_subplot(111)
-
-            # get and plot all value keys
-            if isinstance(entry["keys"], list):
-                # if multiple keys specified as lies
-                for key in entry["keys"]:
-                    # get each one distinctly
-                    values = [
-                        report.get(key, None)
-                        for report_time, report in self.report_store
-                    ]
-                    # then plot
-                    ax.plot(values, label=key)
-
-                # don't forget the legend
-                ax.legend()
+        for key in net_io_counters:
+            if 'loopback' in key.lower():
+                net_io_lo_identifiers.append(key)
+            elif key.lower() == 'lo':
+                net_io_lo_identifiers.append(key)
             else:
-                # if only one key
-                values = [
-                    report.get(entry["keys"], None)
-                    for report_time, report in self.report_store
-                ]
-                ax.plot(values)
-                # no legend needed here
+                net_io_ext_identifiers.append(key)
+        
+        lo_sent_mb = sum(
+            [
+                net_io_counters.get(key).bytes_sent
+                for key in net_io_lo_identifiers
+            ]
+        ) / (1024 * 1024)
 
-            # fancy plotting params
-            ax.set_ylim(bottom=entry.get("bottom", None), top=entry.get("top", None))
-            ax.set_title(entry.get("title", None))
-            plt.xlabel(entry.get("xlabel", "step"))
-            plt.ylabel(entry.get("ylabel", None))
+        ext_sent_mb = sum(
+            [
+                net_io_counters.get(key).bytes_sent
+                for key in net_io_ext_identifiers
+            ]
+        ) / (1024 * 1024)
 
-            # record in mlflow
-            if self.metrics_logger:
-                self.metrics_logger.log_figure(fig, f"perf_node_{self.world_rank}_{entry['file_key']}.png")
+        lo_recv_mb = sum(
+            [
+                net_io_counters.get(key).bytes_recv
+                for key in net_io_lo_identifiers
+            ]
+        ) / (1024 * 1024)
+
+        ext_recv_mb = sum(
+            [
+                net_io_counters.get(key).bytes_recv
+                for key in net_io_ext_identifiers
+            ]
+        ) / (1024 * 1024)
+
+        perf_report["net_io_lo_sent_mb"] = lo_sent_mb
+        perf_report["net_io_ext_sent_mb"] = ext_sent_mb
+        perf_report["net_io_lo_recv_mb"] = lo_recv_mb
+        perf_report["net_io_ext_recv_mb"] = ext_recv_mb
+
+        # END OF REPORT
+        self.call_on_loop(perf_report)
 
     def finalize(self):
         """Ask the thread to finalize (clean)"""
         self.killed = True
         self.join()
-
-
-if __name__ == "__main__":
-    # just for testing locally
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
-    console_handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(name)s : %(message)s')
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
-
-    from metrics import MetricsLogger
-
-    metrics_logger = MetricsLogger("fake.foo")
-
-    logger.info("TEST")
-    perf_report = PerformanceReportingThread(
-        metrics_logger=metrics_logger,
-        store_max_length=10,
-        initial_time_increment=1,
-        report_each_step=True,
-        report_at_finalize=True
-    )
-    perf_report.start()
-
-    time.sleep(10)
-
-    perf_report.finalize()
-
-    metrics_logger.close()

--- a/tests/common/test_perf.py
+++ b/tests/common/test_perf.py
@@ -1,0 +1,58 @@
+"""Tests src/common/metrics.py"""
+import os
+import pytest
+from unittest.mock import call, Mock, patch
+import time
+
+from common.perf import PerformanceReportingThread
+
+def verify_all_perf_report_keys(perf_report):
+    """Helper test function, tests all keys in perf report"""
+    assert isinstance(perf_report, dict)
+
+    required_keys = [
+        "cpu_pct_per_cpu_avg",
+        "cpu_pct_per_cpu_min",
+        "cpu_pct_per_cpu_max",
+        "mem_percent",
+        "disk_usage_percent",
+        "disk_io_read_mb",
+        "disk_io_write_mb",
+        "net_io_lo_sent_mb",
+        "net_io_ext_sent_mb",
+        "net_io_lo_recv_mb",
+        "net_io_ext_recv_mb"
+    ]
+
+    for key in required_keys:
+        assert key in perf_report, f"key {key} should be in the perf report, but instead we find: {list(perf_report.keys())}"
+        assert isinstance(perf_report[key], float) # all metrics are float so far\
+    
+    assert "not_in_perf_report" not in perf_report
+
+
+def test_perf_report_run_as_thread():
+    """ Tests PerformanceReportingThread() as a thread """
+    # creating a mock to provide as callback
+    call_on_loop_method = Mock()
+    call_on_exit_method = Mock()
+
+    perf_report_thread = PerformanceReportingThread(initial_time_increment=2.0)
+    perf_report_thread.call_on_loop = call_on_loop_method
+    perf_report_thread.call_on_exit = call_on_exit_method
+
+    perf_report_thread.start() # will engage in first loop and sleep 2.0
+    time.sleep(0.5) # will wait to be in the middle of that loop
+    perf_report_thread.finalize()
+
+    # on exit not called in this one
+    call_on_exit_method.assert_called_once()
+
+    # get all mock calls
+    callback_call_args = call_on_loop_method.call_args_list
+
+    assert len(callback_call_args) == 1 # just called once
+    assert len(callback_call_args[0].args) == 1 # only 1 argument
+    
+    perf_report = callback_call_args[0].args[0]
+    verify_all_perf_report_keys(perf_report)


### PR DESCRIPTION
This creates a performance measurement thread to capture cpu/mem utilization and other perf related metrics.

The thread is disconnected from the other code from now, but will be built upon in distributed training.