### PR TITLE
Remove singleton from MetricsLogger

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -84,6 +84,9 @@ class RunnableScript():
         """Initialize the component run, opens/setups what needs to be"""
         self.logger.info("Initializing script run...")
 
+        # open mlflow
+        self.metrics_logger.open()
+
         # record properties of the run
         self.metrics_logger.set_properties(
             task = self.task,

--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -73,6 +73,10 @@ class MultiNodeScript(RunnableScript):
     def initialize_run(self, args):
         """Initialize the component run, opens/setups what needs to be"""
         self.logger.info("Initializing multi node component script...")
+
+        # open mlflow
+        self.metrics_logger.open()
+        
         if self._mpi_config.main_node:
             # record properties only from the main node
             self.metrics_logger.set_properties(

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -77,10 +77,13 @@ class MetricsLogger():
         if len(key) > 50:
             key = key[:50]
 
-        try:
-            mlflow.log_metric(key, value, step=step)
-        except mlflow.exceptions.MlflowException:
-            self._logger.critical(f"Could not log metric using MLFLOW due to exception:\n{traceback.format_exc()}")
+        if type == MetricType.PERF_INTERVAL_METRIC:
+            pass # for now, do not process those
+        else:
+            try:
+                mlflow.log_metric(key, value, step=step)
+            except mlflow.exceptions.MlflowException:
+                self._logger.critical(f"Could not log metric using MLFLOW due to exception:\n{traceback.format_exc()}")
 
     def log_figure(self, figure, artifact_file):
         """Logs a figure using mlflow

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -16,6 +16,17 @@ import traceback
 import logging
 
 
+class MetricType():
+    # a metric your script generates once (per node), example: training time
+    ONETIME_METRIC = 1
+
+    # a metric generated multiple times, once per "step" or iteration, example: rmse
+    ITERATION_METRIC = 2
+
+    # a perf metric generated at regular intervals
+    PERF_INTERVAL_METRIC = 2
+
+
 class MetricsLogger():
     """
     Class for handling metrics logging in MLFlow.
@@ -47,13 +58,14 @@ class MetricsLogger():
         """ Removes chars not allowed for metric keys in mlflow """
         return re.sub(r'[^a-zA-Z0-9_\-\.\ \/]', '', name_string)
 
-    def log_metric(self, key, value, step=None):
+    def log_metric(self, key, value, step=None, type=MetricType.ONETIME_METRIC):
         """Logs a metric key/value pair.
-        
+
         Args:
             key (str): metric key
             value (str): metric value
             step (int): which step to log this metric? (see mlflow.log_metric())
+            type (int): type of the metric
         """
         if self._metrics_prefix:
             key = self._metrics_prefix + key

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -16,14 +16,6 @@ import traceback
 import logging
 
 
-class MetricType():
-    # a metric your script generates once (per node), example: training time
-    ONETIME_METRIC = 1
-
-    # a metric generated multiple times, once per "step" or iteration, example: rmse
-    ITERATION_METRIC = 2
-
-
 class MetricsLogger():
     """
     Class for handling metrics logging in MLFlow.

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -15,49 +15,41 @@ import json
 import traceback
 import logging
 
+
+class MetricType():
+    # a metric your script generates once (per node), example: training time
+    ONETIME_METRIC = 1
+
+    # a metric generated multiple times, once per "step" or iteration, example: rmse
+    ITERATION_METRIC = 2
+
+
 class MetricsLogger():
     """
-    Class for handling metrics logging in MLFlow. This class is a singleton.
+    Class for handling metrics logging in MLFlow.
     """
     _initialized = False
-    _instance = None
-    _session_name = None
-    _metrics_prefix = None
-    _logger = logging.getLogger(__name__)
 
-    def __new__(cls, session_name=None, metrics_prefix=None):
-        """ Create a new instance of the Singleton """
-        if not cls._initialized:
-            # if this is the first time we're initializing
-            cls._instance = super(MetricsLogger, cls).__new__(cls)
-            cls._metrics_prefix = metrics_prefix
-            if not cls._session_name:
-                # if no previously recorded session name
-                cls._session_name = session_name
-            elif session_name:
-                # if new session name specified, overwrite
-                cls._session_name = session_name
-            cls._logger.info(f"Initializing MLFLOW [session='{cls._session_name}', metrics_prefix={cls._metrics_prefix}]")
+    def __init__(self, session_name=None, metrics_prefix=None):
+        self._metrics_prefix = metrics_prefix
+        self._session_name = session_name
+        self._logger = logging.getLogger(__name__)
+    
+    def open(self):
+        """Opens the MLFlow session."""
+        if not MetricsLogger._initialized:
+            self._logger.info(f"Initializing MLFLOW [session='{self._session_name}', metrics_prefix={self._metrics_prefix}]")
             mlflow.start_run()
-            cls._initialized = True
-        else:
-            # if this is not the first time, and things are already initialized
-            if not cls._metrics_prefix:
-                cls._logger.warning(f"New creation of MetricsLogger() with a new prefix {metrics_prefix}")
-                cls._metrics_prefix = metrics_prefix
-            pass
+            MetricsLogger._initialized = True
 
-        return cls._instance
-
-    @classmethod
-    def close(cls):
+    def close(self):
         """Close the MLFlow session."""
-        if cls._initialized:
-            cls._logger.info(f"Finalizing MLFLOW [session='{cls._session_name}']")
+        if MetricsLogger._initialized:
+            self._logger.info(f"Finalizing MLFLOW [session='{self._session_name}']")
             mlflow.end_run()
-            cls._initialized = False
+            MetricsLogger._initialized = False
         else:
-            cls._logger.warning(f"Call to finalize MLFLOW [session='{cls._session_name}'] that was never initialized.")
+            self._logger.warning(f"Call to finalize MLFLOW [session='{self._session_name}'] that was never initialized.")
 
     def _remove_non_allowed_chars(self, name_string):
         """ Removes chars not allowed for metric keys in mlflow """
@@ -170,7 +162,7 @@ class MetricsLogger():
         ```
         """
         # see class below with proper __enter__ and __exit__
-        return LogTimeBlock(metric_name, step=step)
+        return LogTimeBlock(metric_name, step=step, metrics_logger=self)
 
     def log_inferencing_latencies(self, time_per_batch, batch_length=1, factor_to_usecs=1000000.0):
         """Logs prediction latencies (for inferencing) with lots of fancy metrics and plots.
@@ -268,6 +260,7 @@ class LogTimeBlock(object):
         # kwargs
         self.tags = kwargs.get('tags', None)
         self.step = kwargs.get('step', None)
+        self.metrics_logger = kwargs.get('metrics_logger', None)
 
         # internal variables
         self.name = name
@@ -288,24 +281,7 @@ class LogTimeBlock(object):
         run_time = time.time() - self.start_time # stops "timer"
 
         self._logger.info(f"--- time elapsed: {self.name} = {run_time:2f} s" + (f" [tags: {self.tags}]" if self.tags else ""))
-        MetricsLogger().log_metric(self.name, run_time, step=self.step)
-
-
-####################
-### METHOD TIMER ###
-####################
-
-def log_time_function(func):
-    """ decorator to log wall time of a function/method """
-    @wraps(func)
-    def perf_wrapper(*args, **kwargs):
-        log_name = "{}.time".format(func.__qualname__)
-        start_time = time.time()
-        output = func(*args, **kwargs)
-        run_time = time.time() - start_time
-
-        logging.getLogger(__name__).info("--- time elapsed: {} = {:2f} s".format(log_name, run_time))
-        MetricsLogger().log_metric(log_name, run_time)
-
-        return output
-    return perf_wrapper
+        if self.metrics_logger:
+            self.metrics_logger.log_metric(self.name, run_time, step=self.step)
+        else:
+            MetricsLogger().log_metric(self.name, run_time, step=self.step)

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -10,10 +10,13 @@ from common.metrics import MetricsLogger
 
 @patch('mlflow.end_run')
 @patch('mlflow.start_run')
-def test_unique_mlflow_initialization(mlflow_start_run_mock, mlflow_end_run_mock):
+def test_unique_mlflow_parallel_initialization(mlflow_start_run_mock, mlflow_end_run_mock):
     """ Tests MetricsLogger() unique initialization of mlflow"""
+    # if open is called twice, we initialize mlflow only once
     metrics_logger = MetricsLogger()
     metrics_logger_2 = MetricsLogger()
+    metrics_logger.open()
+    metrics_logger_2.open()
     metrics_logger.close()
     metrics_logger_2.close()
 
@@ -21,36 +24,61 @@ def test_unique_mlflow_initialization(mlflow_start_run_mock, mlflow_end_run_mock
     mlflow_end_run_mock.assert_called_once()
 
 
+@patch('mlflow.end_run')
+@patch('mlflow.start_run')
+def test_unique_mlflow_sequence_initialization(mlflow_start_run_mock, mlflow_end_run_mock):
+    """ Tests MetricsLogger() unique initialization of mlflow"""
+    # when open/close multiple times in a sequence, we initialize mlflow each time
+    metrics_logger = MetricsLogger()
+    metrics_logger.open()
+    metrics_logger.close()
+
+    assert mlflow_start_run_mock.call_count == 1
+    assert mlflow_end_run_mock.call_count == 1
+
+    metrics_logger_2 = MetricsLogger()
+    metrics_logger_2.open()
+    metrics_logger_2.close()
+
+    assert mlflow_start_run_mock.call_count == 2
+    assert mlflow_end_run_mock.call_count == 2
+
+
 @patch('mlflow.log_metric')
 def test_metrics_logger_log_metric(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger()
+    metrics_logger.open()
+    metrics_logger.log_metric("foo", "bar", step=16)
     metrics_logger.close()
 
-    metrics_logger.log_metric("foo", "bar", step=16)
     mlflow_log_metric_mock.assert_called_with(
         "foo", "bar", step=16
     )
-
 
 
 @patch('mlflow.log_metric')
 def test_metrics_logger_log_metric_with_prefix(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger(metrics_prefix="foo/")
+    metrics_logger.open()
+    metrics_logger.log_metric("foo", "bar", step=16)
     metrics_logger.close()
 
-    metrics_logger.log_metric("foo", "bar", step=16)
     mlflow_log_metric_mock.assert_called_with(
         "foo/foo", "bar", step=16
     )
 
 
 @patch('mlflow.log_metric')
-def test_metrics_logger_log_metric_with_prefix_2sessions(mlflow_log_metric_mock):
+def test_mlflow_metrics_logger_log_metric_with_prefix_2sessions(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
+    # when initializing multiple times, each logger has its own prefix
     metrics_logger = MetricsLogger(metrics_prefix="foo/")
+    metrics_logger.open()
+
     metrics_logger_2 = MetricsLogger()
+    metrics_logger_2.open()
 
     metrics_logger.log_metric("foo", "bar", step=16)
     mlflow_log_metric_mock.assert_called_with(
@@ -59,19 +87,18 @@ def test_metrics_logger_log_metric_with_prefix_2sessions(mlflow_log_metric_mock)
 
     metrics_logger_2.log_metric("foo2", "bar2", step=12)
     mlflow_log_metric_mock.assert_called_with(
-        "foo/foo2", "bar2", step=12
+        "foo2", "bar2", step=12
     )
 
     metrics_logger.close()
     metrics_logger_2.close()
 
 
-
 @patch('mlflow.log_metric')
 def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     metric_key = "x" * 250
     assert len(metric_key), 250
@@ -82,6 +109,9 @@ def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
     metrics_logger.log_metric(
         metric_key, "bar", step=15
     )
+
+    metrics_logger.close()
+
     mlflow_log_metric_mock.assert_called_with(
         short_metric_key, "bar", step=15
     )
@@ -90,7 +120,6 @@ def test_metrics_logger_log_metric_too_long(mlflow_log_metric_mock):
 def test_metrics_logger_log_metric_non_allowed_chars():
     """ Tests MetricsLogger().log_metric() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
 
     test_cases = [
         {
@@ -115,12 +144,13 @@ def test_metrics_logger_log_metric_non_allowed_chars():
 def test_metrics_logger_set_properties(mlflow_set_tags_mock):
     """ Tests MetricsLogger().set_properties() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
-
+    metrics_logger.open()
     metrics_logger.set_properties(
         key1 = "foo",
         key2 = 0.45
     )
+    metrics_logger.close()
+
     mlflow_set_tags_mock.assert_called_with(
         { 'key1' : "foo", 'key2' : 0.45 }
     )
@@ -130,7 +160,7 @@ def test_metrics_logger_set_properties(mlflow_set_tags_mock):
 def test_metrics_logger_set_platform_properties(mlflow_set_tags_mock):
     """ Tests MetricsLogger().set_properties() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     platform_properties = {
         "machine":platform.machine(),
@@ -145,6 +175,8 @@ def test_metrics_logger_set_platform_properties(mlflow_set_tags_mock):
     }
     metrics_logger.set_platform_properties()
 
+    metrics_logger.close()
+
     mlflow_set_tags_mock.assert_called_with(
         platform_properties
     )
@@ -153,7 +185,7 @@ def test_metrics_logger_set_platform_properties(mlflow_set_tags_mock):
 def test_metrics_logger_set_properties_from_json(mlflow_set_tags_mock):
     """ Tests MetricsLogger().set_properties_from_json() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     metrics_logger.set_properties_from_json(
         "{ \"key1\" : \"foo\", \"key2\" : 0.45 }"
@@ -178,17 +210,22 @@ def test_metrics_logger_set_properties_from_json(mlflow_set_tags_mock):
     # making sure it's the right exception
     assert str(exc_info.value).startswith("Provided JSON properties should be a dict")
 
+    metrics_logger.close()
+
 @patch('mlflow.log_param')
 def test_metrics_logger_log_parameters(mlflow_log_param_mock):
     """ Tests MetricsLogger().log_parameters() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     metrics_logger.log_parameters(
         key1 = "foo",
         key2 = 0.45,
         str_way_too_long = ("*" * 1024)
     )
+
+    metrics_logger.close()
+
     mlflow_log_param_mock.assert_has_calls(
         [
             call("key1", "foo"),
@@ -202,10 +239,12 @@ def test_metrics_logger_log_parameters(mlflow_log_param_mock):
 def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_time_block() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     with metrics_logger.log_time_block("foo_metric", step=2):
         time.sleep(0.01)
+
+    metrics_logger.close()
 
     # there should be only one call in this case
     metric_calls = mlflow_log_metric_mock.call_args_list
@@ -219,15 +258,17 @@ def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
 
 @patch('mlflow.log_figure')
 @patch('mlflow.log_metric')
-def test_log_inferencing_larencies(mlflow_log_metric_mock, mlflow_log_figure_mock):
+def test_log_inferencing_latencies(mlflow_log_metric_mock, mlflow_log_figure_mock):
     """ Tests MetricsLogger().log_inferencing_larencies() """
     metrics_logger = MetricsLogger()
-    metrics_logger.close()
+    metrics_logger.open()
 
     test_latencies = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 5.0]
     test_batch_sizes = [1, 1, 1, 1, 1, 1, 1, 5]
 
     metrics_logger.log_inferencing_latencies(test_latencies, batch_length=test_batch_sizes, factor_to_usecs=1000000.0)
+
+    metrics_logger.close()
 
     #assert mlflow_log_metric_mock.call_args_list == []
 

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -238,7 +238,7 @@ def test_metrics_logger_log_parameters(mlflow_log_param_mock):
 @patch('mlflow.log_metric')
 def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
     """ Tests MetricsLogger().log_time_block() """
-    metrics_logger = MetricsLogger()
+    metrics_logger = MetricsLogger(metrics_prefix="foo_time_block/")
     metrics_logger.open()
 
     with metrics_logger.log_time_block("foo_metric", step=2):
@@ -252,7 +252,7 @@ def test_metrics_logger_log_time_block(mlflow_log_metric_mock):
     assert len(metric_calls) == 1
 
     # test metric key argument
-    assert (metric_calls[0].args[0] == "foo_metric")
+    assert (metric_calls[0].args[0] == "foo_time_block/foo_metric")
     assert (metric_calls[0].kwargs["step"] == 2)
 
 


### PR DESCRIPTION
This PR removes the mechanism establishing MetricsLogger as a Singleton. This was introduces in the beginning to support recording metrics from all over the place, but this is now deprecated since we have clean components classes.

Also, this introduces metric types that are not required, but will be helpful for integrating performance metrics and distributed metrics.