### PR TITLE
Add a perf metric collector to ensure number of measures stays under control

### DIFF
--- a/src/common/perf.py
+++ b/src/common/perf.py
@@ -14,8 +14,20 @@ import psutil
 class PerformanceReportingThread(threading.Thread):
     """Thread to report performance (cpu/mem/net)"""
     def __init__(self,
-                 initial_time_increment=1.0):
-        """Constructor"""
+                 initial_time_increment=1.0,
+                 cpu_interval=1.0,
+                 callback_on_loop=None,
+                 callback_on_exit=None,
+                 callback_tags={}):
+        """Constructor
+        
+        Args:
+            initial_time_increment (float): how much time to sleep between perf readings
+            cpu_interval (float): interval to capture cpu utilization
+            callback_on_loop (func): function to call when a perf reading is issued
+            callback_on_exit (func): function to call when thread is finalized
+            callback_tags (dict): keyword args to add to call to callback_on_loop
+        """
         threading.Thread.__init__(self)
         self.killed = False # flag, set to True to kill from the inside
 
@@ -23,19 +35,12 @@ class PerformanceReportingThread(threading.Thread):
 
         # time between perf reports
         self.time_increment = initial_time_increment
+        self.cpu_interval = cpu_interval
 
+        # set callbacks
+        self.callback_on_loop = callback_on_loop
+        self.callback_on_exit = callback_on_exit
 
-    ##################
-    ### CALL BACKS ###
-    ##################
-
-    def call_on_loop(self, perf_report):
-        """You need to implement this"""
-        pass
-
-    def call_on_exit(self):
-        """You need to implement this"""
-        pass
 
     #####################
     ### RUN FUNCTIONS ###
@@ -44,18 +49,19 @@ class PerformanceReportingThread(threading.Thread):
     def run(self):
         """Run function of the thread, while(True)"""
         while not(self.killed):
-            if self.time_increment >= 1.0: # cpu_percent.interval already consumes 1sec
-                time.sleep(self.time_increment - 1.0) # will double every time report_store_max_length is reached
+            if self.time_increment >= self.cpu_interval: # cpu_percent.interval already consumes 1sec
+                time.sleep(self.time_increment - self.cpu_interval) # will double every time report_store_max_length is reached
             self._run_loop()
 
-        self.call_on_exit()
+        if self.callback_on_exit:
+            self.callback_on_exit()
 
     def _run_loop(self):
         """What to run within the while(not(killed))"""
         perf_report = {}
 
         # CPU UTILIZATION
-        cpu_utilization = psutil.cpu_percent(interval=1.0, percpu=True) # will take 1 sec to return
+        cpu_utilization = psutil.cpu_percent(interval=self.cpu_interval, percpu=True) # will take 1 sec to return
         perf_report["cpu_pct_per_cpu_avg"] = sum(cpu_utilization) / len(cpu_utilization)
         perf_report["cpu_pct_per_cpu_min"] = min(cpu_utilization)
         perf_report["cpu_pct_per_cpu_max"] = max(cpu_utilization)
@@ -114,10 +120,69 @@ class PerformanceReportingThread(threading.Thread):
         perf_report["net_io_lo_recv_mb"] = lo_recv_mb
         perf_report["net_io_ext_recv_mb"] = ext_recv_mb
 
+        # add a timestamp
+        perf_report["timestamp"] = time.time()
+
         # END OF REPORT
-        self.call_on_loop(perf_report)
+        if self.callback_on_loop:
+            self.callback_on_loop(perf_report)
 
     def finalize(self):
         """Ask the thread to finalize (clean)"""
         self.killed = True
         self.join()
+
+
+class PerformanceMetricsCollector():
+    """Collects performance metrics from PerformanceReportingThread
+    Limits all values to a maximum length"""
+    def __init__(self, max_length=1000):
+        """Constructor
+        
+        Args:
+            max_length (int): maximum number of perf reports to keep
+        """
+        self.logger = logging.getLogger(__name__)
+
+        # create a thread to generate reports regularly
+        self.report_thread = PerformanceReportingThread(
+            initial_time_increment=1.0,
+            cpu_interval=1.0,
+            callback_on_loop=self.append_perf_metrics
+        )
+
+        self.perf_reports = [] # internal storage
+        self.perf_reports_freqs = 1 # frequency to skip reports from thread
+        self.perf_reports_counter = 0 # how many reports we had so far
+
+        self.max_length = (max_length//2 + max_length%2) * 2 # has to be dividable by 2
+
+
+    def start(self):
+        """Start collector perf metrics (start internal thread)"""
+        self.logger.info(f"Starting perf metric collector (max_length={self.max_length})")
+        self.report_thread.start()
+
+    def finalize(self):
+        """Stop collector perf metrics (stop internal thread)"""
+        self.logger.info(f"Finalizing perf metric collector (length={len(self.perf_reports)})")
+        self.report_thread.finalize()
+
+    def append_perf_metrics(self, perf_metrics):
+        """Add a perf metric report to the internal storage"""
+        self.perf_reports_counter += 1
+
+        if (self.perf_reports_counter % self.perf_reports_freqs):
+            # if we've decided to skip this one
+            return
+
+        self.perf_reports.append(perf_metrics)
+
+        if len(self.perf_reports) > self.max_length:
+            # trim the report by half
+            self.perf_reports = [
+                self.perf_reports[i]
+                for i in range(0, self.max_length, 2)
+            ]
+            self.perf_reports_freqs *= 2 # we'll start accepting reports only 1 out of 2
+            self.logger.warning(f"Perf report store reached max, increasing freq to {self.perf_reports_freqs}")

--- a/src/common/perf.py
+++ b/src/common/perf.py
@@ -17,8 +17,7 @@ class PerformanceReportingThread(threading.Thread):
                  initial_time_increment=1.0,
                  cpu_interval=1.0,
                  callback_on_loop=None,
-                 callback_on_exit=None,
-                 callback_tags={}):
+                 callback_on_exit=None):
         """Constructor
         
         Args:
@@ -26,7 +25,6 @@ class PerformanceReportingThread(threading.Thread):
             cpu_interval (float): interval to capture cpu utilization
             callback_on_loop (func): function to call when a perf reading is issued
             callback_on_exit (func): function to call when thread is finalized
-            callback_tags (dict): keyword args to add to call to callback_on_loop
         """
         threading.Thread.__init__(self)
         self.killed = False # flag, set to True to kill from the inside

--- a/tests/common/test_perf.py
+++ b/tests/common/test_perf.py
@@ -4,11 +4,13 @@ import pytest
 from unittest.mock import call, Mock, patch
 import time
 
-from common.perf import PerformanceReportingThread
+from common.perf import PerformanceReportingThread, PerformanceMetricsCollector
 
 def verify_all_perf_report_keys(perf_report):
     """Helper test function, tests all keys in perf report"""
     assert isinstance(perf_report, dict)
+
+    assert "timestamp" in perf_report, "perf report should have a timestamp key"
 
     required_keys = [
         "cpu_pct_per_cpu_avg",
@@ -27,7 +29,7 @@ def verify_all_perf_report_keys(perf_report):
     for key in required_keys:
         assert key in perf_report, f"key {key} should be in the perf report, but instead we find: {list(perf_report.keys())}"
         assert isinstance(perf_report[key], float) # all metrics are float so far\
-    
+
     assert "not_in_perf_report" not in perf_report
 
 
@@ -56,3 +58,40 @@ def test_perf_report_run_as_thread():
     
     perf_report = callback_call_args[0].args[0]
     verify_all_perf_report_keys(perf_report)
+
+
+def test_perf_report_collector_run_as_thread():
+    """ Tests PerformanceMetricsCollector() """
+    # creating a mock to provide as callback
+    test_max_length = 10
+
+    perf_collector = PerformanceMetricsCollector(max_length=test_max_length)
+
+    # hack internal values to make the test faster
+    perf_collector.report_thread.cpu_interval = 0.01
+    perf_collector.report_thread.time_increment = 0.02
+
+    # fake the loop in the internal thread
+
+    # if we run the exact times we can hold
+    for i in range(test_max_length):
+        perf_collector.report_thread._run_loop()
+    # we expect to have internal list full
+    assert len(perf_collector.perf_reports) > 0
+    assert len(perf_collector.perf_reports) == test_max_length
+
+    # 1 more time...
+    perf_collector.report_thread._run_loop()
+    # and length should be half
+    assert len(perf_collector.perf_reports) == (test_max_length // 2)
+    # and frequency increased
+    assert perf_collector.perf_reports_freqs == 2
+
+    # then every other report should be skipped
+    for i in range(4):
+        perf_collector.report_thread._run_loop()
+    # and length should be half + 2 new values
+    assert len(perf_collector.perf_reports) == (test_max_length // 2) + 2
+
+    for report in perf_collector.perf_reports:
+        verify_all_perf_report_keys(report)

--- a/tests/common/test_perf.py
+++ b/tests/common/test_perf.py
@@ -39,9 +39,11 @@ def test_perf_report_run_as_thread():
     call_on_loop_method = Mock()
     call_on_exit_method = Mock()
 
-    perf_report_thread = PerformanceReportingThread(initial_time_increment=2.0)
-    perf_report_thread.call_on_loop = call_on_loop_method
-    perf_report_thread.call_on_exit = call_on_exit_method
+    perf_report_thread = PerformanceReportingThread(
+        initial_time_increment=2.0,
+        callback_on_loop=call_on_loop_method,
+        callback_on_exit=call_on_exit_method
+    )
 
     perf_report_thread.start() # will engage in first loop and sleep 2.0
     time.sleep(0.5) # will wait to be in the middle of that loop


### PR DESCRIPTION
This PR implements a "collector" on top of the perf measurement thread, that keeps receiving perf reports from the thread, but will keep only a maximum number of reports per run. Every time maximum is reached, the collector will filter out values and start skipping reports.