### PR TITLE
Use github action to test all dockerfiles in script directories (defaults)

### DIFF
--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -29,6 +29,9 @@ jobs:
           - docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
           - docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
           - docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
+          - src/scripts/training/lightbm_python/default.dockerfile
+          - src/scripts/inferencing/lightbm_python/default.dockerfile
+          - src/scripts/inferencing/lightgbm_c_api/default.dockerfile
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +53,7 @@ jobs:
     - uses: marceloprado/has-changed-path@v1
       id: dockerfile-changed
       with:
-        paths: docker/${{ matrix.dockerfile}}
+        paths: ${{ matrix.dockerfile}}
 
     - name: Build the Docker image
       if: steps.dockerfile-changed.outputs.changed == 'true'

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
-          - lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
-          - lightgbm-v3.2.1/linux_cuda_build.dockerfile
-          - lightgbm-v3.2.1/linux_gpu_build.dockerfile
-          - lightgbm-v3.2.1/linux_gpu_pip.dockerfile
-          - lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
-          - lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
-          - lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
+          - docker/lightgbm-v3.2.1/linux_cpu_mpi_build.dockerfile
+          - docker/lightgbm-v3.2.1/linux_cpu_mpi_pip.dockerfile
+          - docker/lightgbm-v3.2.1/linux_cuda_build.dockerfile
+          - docker/lightgbm-v3.2.1/linux_gpu_build.dockerfile
+          - docker/lightgbm-v3.2.1/linux_gpu_pip.dockerfile
+          - docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
+          - docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
+          - docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
 
     steps:
     - uses: actions/checkout@v2
@@ -55,7 +55,6 @@ jobs:
     - name: Build the Docker image
       if: steps.dockerfile-changed.outputs.changed == 'true'
       run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s) --build-arg lightgbm_benchmark_branch=$GIT_BRANCH_NAME
-      working-directory: docker/
 
   windows_container_build:
 
@@ -64,8 +63,8 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - lightgbm-v3.2.1/windows_cpu_pip.dockerfile
-          - lightgbm-v3.3.0/windows_cpu_pip.dockerfile
+          - docker/lightgbm-v3.2.1/windows_cpu_pip.dockerfile
+          - docker/lightgbm-v3.3.0/windows_cpu_pip.dockerfile
 
     steps:
     - uses: actions/checkout@v2
@@ -80,4 +79,3 @@ jobs:
     - name: Build the Docker image
       if: steps.dockerfile-changed.outputs.changed == 'true'
       run: docker build . --file ${{ matrix.dockerfile }} --tag temp:$(date +%s)
-      working-directory: docker/

--- a/.github/workflows/docker_images.yml
+++ b/.github/workflows/docker_images.yml
@@ -29,8 +29,8 @@ jobs:
           - docker/lightgbm-v3.3.0/linux_cpu_mpi_build.dockerfile
           - docker/lightgbm-v3.3.0/linux_cpu_mpi_pip.dockerfile
           - docker/lightgbm-custom/v321_patch_cpu_mpi_build.dockerfile
-          - src/scripts/training/lightbm_python/default.dockerfile
-          - src/scripts/inferencing/lightbm_python/default.dockerfile
+          - src/scripts/training/lightgbm_python/default.dockerfile
+          - src/scripts/inferencing/lightgbm_python/default.dockerfile
           - src/scripts/inferencing/lightgbm_c_api/default.dockerfile
 
     steps:

--- a/src/scripts/inferencing/lightgbm_python/default.dockerfile
+++ b/src/scripts/inferencing/lightgbm_python/default.dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
-LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211111.1"
+LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211210.1"
 
 # Those arguments will NOT be used by AzureML
 # they are here just to allow for lightgbm-benchmark build to actually check


### PR DESCRIPTION
This PR changes the github action that tests all dockerfiles so that we can also test `default.dockerfile` located within the `src/scripts/` tree.

It also updated one such dockerfile just for testing the build.