### PR TITLE
add try/except around component run

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -170,8 +170,14 @@ class RunnableScript():
         script_instance = cls()
         script_instance.initialize_run(args)
 
-        # run the actual thing
-        script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
+        # catch run function exceptions to properly finalize run (kill/join threads)
+        try:
+            # run the actual thing
+            script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
+        except BaseException as e:
+            logging.critical(f"Exception occured during run():\n{traceback.format_exc()}")
+            script_instance.finalize_run(args)
+            raise e
 
         # close mlflow
         script_instance.finalize_run(args)

--- a/tests/common/test_component.py
+++ b/tests/common/test_component.py
@@ -21,6 +21,7 @@ class FakeSingleNodeScript(SingleNodeScript):
         with metrics_logger.log_time_block("fake_time_block", step=1):
             time.sleep(1)
 
+
 @patch('mlflow.end_run')
 @patch('mlflow.log_metric')
 @patch('mlflow.set_tags')
@@ -101,3 +102,34 @@ def test_single_node_script_metrics(mlflow_start_run_mock, mlflow_set_tags_mock,
         assert metrics_calls[index+1].args[0] == MetricsLogger._remove_non_allowed_chars(metric_key)
         assert "step" in metrics_calls[index+1].kwargs
         assert metrics_calls[index+1].kwargs["step"] == 0 # using node id as step
+
+
+class FailingSingleNodeScript(SingleNodeScript):
+    def __init__(self):
+        super().__init__(
+            task="failure",
+            framework="pytest",
+            framework_version=pytest.__version__
+        )
+
+    def run(self, args, logger, metrics_logger, unknown_args):
+        # don't do anything
+        with metrics_logger.log_time_block("fake_time_block", step=1):
+            time.sleep(1)
+            raise Exception("Some fake issue occured during code!")
+
+
+@patch('mlflow.end_run')
+@patch('mlflow.log_metric')
+@patch('mlflow.set_tags')
+@patch('mlflow.start_run')
+def test_single_node_script_metrics(mlflow_start_run_mock, mlflow_set_tags_mock, mlflow_log_metric_mock, mlflow_end_run_mock):
+    # just run main
+    with pytest.raises(Exception) as e_test:
+        test_component = FailingSingleNodeScript.main(
+            [
+                "foo.py",
+                "--verbose", "True",
+                "--custom_properties", json.dumps({'benchmark_name':'unittest'})
+            ]
+        )

--- a/tests/common/test_component.py
+++ b/tests/common/test_component.py
@@ -119,11 +119,7 @@ class FailingSingleNodeScript(SingleNodeScript):
             raise Exception("Some fake issue occured during code!")
 
 
-@patch('mlflow.end_run')
-@patch('mlflow.log_metric')
-@patch('mlflow.set_tags')
-@patch('mlflow.start_run')
-def test_single_node_script_metrics(mlflow_start_run_mock, mlflow_set_tags_mock, mlflow_log_metric_mock, mlflow_end_run_mock):
+def test_failure_single_node_script_metrics():
     # just run main
     with pytest.raises(Exception) as e_test:
         test_component = FailingSingleNodeScript.main(


### PR DESCRIPTION
This PR implements a try/except around run method in component helper class. There reason is, now that we have perf metrics produced by threads, we want to avoid the job to hang if the run function breaks. We still raise the exception so it shows in AzureML.