### PR TITLE
Implement tests on MultiNodeScript class by separating mpi initialization

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -182,5 +182,8 @@ class RunnableScript():
         # close mlflow
         script_instance.finalize_run(args)
 
+        # return for unit tests
+        return script_instance
+
 class SingleNodeScript(RunnableScript):
     pass

--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -4,51 +4,95 @@
 """
 LightGBM/Python training script
 """
-import os
-import sys
-import argparse
 import logging
 import traceback
-import json
-from mpi4py import MPI
 from .components import RunnableScript
-from collections import namedtuple
+from dataclasses import dataclass
+from omegaconf import MISSING
 
 from .perf import PerformanceMetricsCollector, PerfReportPlotter
 
-def detect_mpi_config():
-    """ Detects if we're running in MPI.
-    Args:
-        None
+@dataclass
+class mpi_config_class:
+    world_size: int = MISSING
+    world_rank: int = MISSING
+    mpi_available: bool = MISSING
+    main_node: bool = MISSING
 
-    Returns:
-        mpi_config (namedtuple)
-    """
-    # check if we're running multi or single node
-    mpi_config_tuple = namedtuple("mpi_config", ['world_size', 'world_rank', 'mpi_available', 'main_node'])
+class MPIHandler():
+    """Handling MPI initialization in a separate class
+    so we can patch/mock it during unit testing of MultiNodeScript"""
+    def __init__(self, mpi_init_mode=None):
+        """Constructor"""
+        self._mpi_module = None
+        self._comm = None
+        self._mpi_config = None
+        self._mpi_init_mode = mpi_init_mode
+        self.logger = logging.getLogger(__name__)
 
-    try:
-        comm = MPI.COMM_WORLD
-        mpi_config = mpi_config_tuple(
-            comm.Get_size(), # world_size
-            comm.Get_rank(), # world_rank
-            (comm.Get_size() > 1), # mpi_available
-            (comm.Get_rank() == 0), # main_node
-        )
-        logging.getLogger().info(f"MPI detection results: {mpi_config}")
-    except:
-        mpi_config = mpi_config_tuple(
-            1, # world_size
-            0, # world_rank
-            False, # mpi_available
-            True, # main_node
-        )
-        logging.getLogger().critical(f"MPI detection failed, switching to single node: {mpi_config}, see traceback below:\n{traceback.format_exc()}")
+    def _mpi_import(self):
+        if self._mpi_module is None:
+            import mpi4py
+            mpi4py.rc.initialize = False
+            mpi4py.rc.finalize = False
+            from mpi4py import MPI
+            self._mpi_module = MPI
 
-    return mpi_config
+        return self._mpi_module
+
+    def initialize(self):
+        # doing our own initialization of MPI to have fine-grain control
+        self._mpi_import()
+        self.comm = self._mpi_module.COMM_WORLD
+
+        if self._mpi_init_mode is None:
+            self._mpi_init_mode = self._mpi_module.THREAD_MULTIPLE
+
+        try:
+            self._mpi_module.Init_thread(required=self._mpi_init_mode)
+        except self._mpi_module.Exception:
+            self.logger.warning(f"Exception occured during MPI initialization:\n{traceback.format_exc()}")
+
+        self._mpi_config = self.detect_mpi_config()
+
+    def finalize(self):
+        if self._mpi_module.Is_initialized():
+            self.logger.info("MPI was initialized, calling MPI.finalize()")
+            self._mpi_module.Finalize()
+
+    def mpi_config(self):
+        return self._mpi_config
+
+    def detect_mpi_config(self):
+        """ Detects if we're running in MPI.
+        Args:
+            None
+
+        Returns:
+            mpi_config (namedtuple)
+        """
+        try:
+            mpi_config = mpi_config_class(
+                self.comm.Get_size(), # world_size
+                self.comm.Get_rank(), # world_rank
+                (self.comm.Get_size() > 1), # mpi_available
+                (self.comm.Get_rank() == 0), # main_node
+            )
+            logging.getLogger().info(f"MPI detection results: {mpi_config}")
+        except:
+            mpi_config = mpi_config_class(
+                1, # world_size
+                0, # world_rank
+                False, # mpi_available
+                True, # main_node
+            )
+            logging.getLogger().critical(f"MPI detection failed, switching to single node: {mpi_config}, see traceback below:\n{traceback.format_exc()}")
+
+        return mpi_config
+
 
 class MultiNodeScript(RunnableScript):
-    def __init__(self, task, framework, framework_version, metrics_prefix=None):
+    def __init__(self, task, framework, framework_version, metrics_prefix=None, mpi_init_mode=None):
         """ Generic initialization for all script classes.
 
         Args:
@@ -56,6 +100,7 @@ class MultiNodeScript(RunnableScript):
             framework (str): name of ML framework
             framework_version (str): a version of this framework
             metrics_prefix (str): any prefix to add to this scripts metrics
+            mpi_init_mode (int): mode to initialize MPI
         """
         # just use the regular init
         super().__init__(
@@ -65,16 +110,20 @@ class MultiNodeScript(RunnableScript):
             metrics_prefix = metrics_prefix
         )
 
-        # but also add mpi_config
-        self._mpi_config = detect_mpi_config()
+        self._mpi_handler = MPIHandler(mpi_init_mode=mpi_init_mode)
+        self._mpi_config = None
 
     def mpi_config(self):
-        """Getter method"""
+        """Getter"""
         return self._mpi_config
 
     def initialize_run(self, args):
         """Initialize the component run, opens/setups what needs to be"""
         self.logger.info("Initializing multi node component script...")
+
+        self.logger.info("Initializing MPI.")
+        self._mpi_handler.initialize()
+        self._mpi_config = self._mpi_handler.mpi_config()
 
         # open mlflow
         self.metrics_logger.open()
@@ -103,11 +152,11 @@ class MultiNodeScript(RunnableScript):
     def finalize_run(self, args):
         """Finalize the run, close what needs to be"""
         self.logger.info("Finalizing multi node component script...")
+
         # clean exit from mpi
-        if MPI.Is_initialized():
-            self.logger.info("MPI was initialized, calling MPI.finalize()")
-            MPI.Finalize()
-        
+        self.logger.info("Finalizing MPI.")
+        self._mpi_handler.finalize()
+
         if self.perf_report_collector:
             self.perf_report_collector.finalize()
             plotter = PerfReportPlotter(self.metrics_logger)

--- a/tests/common/test_distributed.py
+++ b/tests/common/test_distributed.py
@@ -1,0 +1,66 @@
+"""Tests src/common/io.py"""
+import os
+import pytest
+from unittest.mock import call, Mock, patch
+import time
+import json
+
+from common.distributed import MultiNodeScript, mpi_config_class
+from common.metrics import MetricsLogger
+from test_component import (
+    assert_runnable_script_properties,
+    assert_runnable_script_metrics
+)
+
+class FakeMultiNodeScript(MultiNodeScript):
+    def __init__(self):
+        super().__init__(
+            task="unittest",
+            framework="pytest",
+            framework_version=pytest.__version__
+        )
+
+    def run(self, args, logger, metrics_logger, unknown_args):
+        # don't do anything
+        with metrics_logger.log_time_block("fake_time_block", step=1):
+            time.sleep(1)
+
+
+@patch('mlflow.end_run')
+@patch('mlflow.log_metric')
+@patch('mlflow.set_tags')
+@patch('mlflow.start_run')
+@patch('common.distributed.MPIHandler')
+def test_multi_node_script_metrics(mpi_handler_mock, mlflow_start_run_mock, mlflow_set_tags_mock, mlflow_log_metric_mock, mlflow_end_run_mock):
+    # fake mpi initialization + config
+    mpi_handler_mock().mpi_config.return_value = mpi_config_class(
+        1, # world_size
+        0, # world_rank
+        False, # mpi_available
+        True, # main_node
+    )
+
+    # then just run main
+    test_component = FakeMultiNodeScript.main(
+        [
+            "foo.py",
+            "--verbose", "True",
+            "--custom_properties", json.dumps({'benchmark_name':'unittest'})
+        ]
+    )
+
+    # mlflow initialization
+    mlflow_start_run_mock.assert_called_once()
+    mlflow_end_run_mock.assert_called_once()
+
+    assert_runnable_script_properties(
+        test_component,
+        "unittest",
+        mlflow_set_tags_mock
+    )
+
+    assert_runnable_script_metrics(
+        test_component,
+        [{'key':'fake_time_block', 'step':1}], # user_metrics
+        mlflow_log_metric_mock
+    )

--- a/tests/common/test_distributed.py
+++ b/tests/common/test_distributed.py
@@ -6,7 +6,6 @@ import time
 import json
 
 from common.distributed import MultiNodeScript, mpi_config_class
-from common.metrics import MetricsLogger
 from test_component import (
     assert_runnable_script_properties,
     assert_runnable_script_metrics

--- a/tests/scripts/test_lightgbm_python.py
+++ b/tests/scripts/test_lightgbm_python.py
@@ -10,10 +10,12 @@ from unittest.mock import patch
 
 from scripts.training.lightgbm_python import train
 from scripts.inferencing.lightgbm_python import score
+from common.distributed import mpi_config_class
 
 # IMPORTANT: see conftest.py for fixtures
 
-def test_lightgbm_python_train(temporary_dir, regression_train_sample, regression_test_sample):
+@patch('common.distributed.MPIHandler')
+def test_lightgbm_python_train(mpi_handler_mock, temporary_dir, regression_train_sample, regression_test_sample):
     """Tests src/scripts/training/lightgbm_python/train.py"""
     model_dir = os.path.join(temporary_dir, "model")
 
@@ -37,6 +39,14 @@ def test_lightgbm_python_train(temporary_dir, regression_train_sample, regressio
         "--feature_fraction", "0.15",
         "--device_type", "cpu"
     ]
+
+    # fake mpi initialization + config
+    mpi_handler_mock().mpi_config.return_value = mpi_config_class(
+        1, # world_size
+        0, # world_rank
+        False, # mpi_available
+        True, # main_node
+    )
 
     # replaces sys.argv with test arguments and run main
     with patch.object(sys, "argv", script_args):


### PR DESCRIPTION
This PR makes it possible to unit test distributed component (see issue #196) by containing MPI initialization inside a specific class (`MPIHandler`) and patching it during the unit tests.

Changes:
- in common.distributed: creation of `MPIHandler` to handle all calls to MPI library
- in tests.common.test_component: separate functions to test properties and metrics, so we can reuse in testing distributed component
- in tests.common: add test_distributed to test MultiNodeScript (both success and failure)