### PR TITLE
Make MPI initialization optional and use OMPI env vars for world discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ outputs/
 # ignore aml references
 conf/aml/
 conf/compute/
+conf/experiments/prod/
 src/scripts/inferencing/custom_win_cli/static_binaries/

--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -68,6 +68,7 @@ class MPIHandler():
             self.comm = self._mpi_module.COMM_WORLD
             self._mpi_config = self.detect_mpi_config()
 
+        logging.getLogger().info(f"MPI detection results: {self._mpi_config}")
 
     def finalize(self):
         if self._mpi_module.Is_initialized() and not self._mpi_module.Is_finalized():
@@ -94,7 +95,6 @@ class MPIHandler():
                 (self.comm.Get_size() > 1), # mpi_available
                 (self.comm.Get_rank() == 0), # main_node
             )
-            logging.getLogger().info(f"MPI detection results: {mpi_config}")
         except:
             mpi_config = mpi_config_class(
                 1, # world_size

--- a/src/scripts/training/lightgbm_python/default.dockerfile
+++ b/src/scripts/training/lightgbm_python/default.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04:20210615.v1
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:latest
 LABEL lightgbmbenchmark.linux.cpu.mpi.pip.version="3.3.0/20211111.1"
 
 # Those arguments will NOT be used by AzureML


### PR DESCRIPTION
The initialization of MPI in python might interact with the initialization done by the framework themselves (ex: lighgbm training). We might still need it in some scenarios (sharing distributed metrics like in #185), so we're making this optional for now.

When mpi_init_node is left to None, we use OMPI env variables to discover how many nodes there are, and create the right configuration for the distributed script to use.

We're also proposing to upgrade to openmpi4.

NOTE: this is part of an effort to try this distributed training on production scenarios where we're hitting internal mpi exceptions (MPI_ERR_TRUNCATE).