### PR TITLE
Generate bigger synthetic data using per-batch generation [regression only]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ azure-ml-component==0.9.4.post1  # for component dsl
 azureml-train-core==1.36.0  # for azureml.train.hyperdrive
 azureml-dataset-runtime==1.36.0  # to register dataset
 hydra-core~=1.0.3
+typing_extensions==4.0.1 # for hydra
 omegaconf~=2.1
 treelite==2.1.0
 treelite_runtime==2.1.0

--- a/src/common/data.py
+++ b/src/common/data.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+# derived from https://github.com/scikit-learn/scikit-learn/blob/7e1e6d09bcc2eaeba98f7e737aac2ac782f0e5f1/sklearn/datasets/_samples_generator.py#L506
+# for generating data in batches
+class RegressionDataGenerator():
+    def __init__(self,
+                 n_features: int,
+                 n_informative: int,
+                 n_targets: int,
+                 bias: float,
+                 noise: float,
+                 seed: int):
+        self.n_features = n_features
+        self.n_informative = min(n_features, n_informative)
+        self.n_targets = n_targets
+        self.bias = bias
+        self.noise = noise
+        self.generator = np.random.RandomState(seed)
+
+        # Generate a ground truth model with only n_informative features being non-zeros
+        self.ground_truth = np.zeros((self.n_features, self.n_targets))
+        self.ground_truth[:n_informative, :] = 100 * self.generator.rand(self.n_informative, self.n_targets)
+
+    def generate_batch(self, batch_size):
+        # Randomly generate a well conditioned input set
+        X = self.generator.randn(batch_size, self.n_features)
+
+        y = np.dot(X, self.ground_truth) + self.bias
+
+        # Add noise
+        if self.noise > 0.0:
+            y += self.generator.normal(scale=self.noise, size=y.shape)
+
+        y = np.squeeze(y)
+
+        return X, y

--- a/src/common/data.py
+++ b/src/common/data.py
@@ -4,12 +4,14 @@ import numpy as np
 # for generating data in batches
 class RegressionDataGenerator():
     def __init__(self,
+                 batch_size: int,
                  n_features: int,
                  n_informative: int,
                  n_targets: int,
                  bias: float,
                  noise: float,
                  seed: int):
+        self.batch_size = batch_size
         self.n_features = n_features
         self.n_informative = min(n_features, n_informative)
         self.n_targets = n_targets
@@ -21,9 +23,9 @@ class RegressionDataGenerator():
         self.ground_truth = np.zeros((self.n_features, self.n_targets))
         self.ground_truth[:n_informative, :] = 100 * self.generator.rand(self.n_informative, self.n_targets)
 
-    def generate_batch(self, batch_size):
+    def generate(self):
         # Randomly generate a well conditioned input set
-        X = self.generator.randn(batch_size, self.n_features)
+        X = self.generator.randn(self.batch_size, self.n_features)
 
         y = np.dot(X, self.ground_truth) + self.bias
 

--- a/src/common/data.py
+++ b/src/common/data.py
@@ -1,8 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Helper code to handle/process data
+"""
+
 import numpy as np
 
 # derived from https://github.com/scikit-learn/scikit-learn/blob/7e1e6d09bcc2eaeba98f7e737aac2ac782f0e5f1/sklearn/datasets/_samples_generator.py#L506
 # for generating data in batches
 class RegressionDataGenerator():
+    """Generator for regression data"""
     def __init__(self,
                  batch_size: int,
                  n_features: int,
@@ -11,6 +19,7 @@ class RegressionDataGenerator():
                  bias: float,
                  noise: float,
                  seed: int):
+        """Initializes the generator"""
         self.batch_size = batch_size
         self.n_features = n_features
         self.n_informative = min(n_features, n_informative)
@@ -24,6 +33,12 @@ class RegressionDataGenerator():
         self.ground_truth[:n_informative, :] = 100 * self.generator.rand(self.n_informative, self.n_targets)
 
     def generate(self):
+        """Generate one batch of data.
+
+        Returns:
+            X (numpy.ndarray)
+            y (numpy.ndarray)
+        """
         # Randomly generate a well conditioned input set
         X = self.generator.randn(self.batch_size, self.n_features)
 

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -32,8 +32,11 @@ class data_generation_task:
     task: str = MISSING
     task_key: Optional[str] = None
     train_samples: int = MISSING
+    train_partitions: int = 1
     test_samples: int = MISSING
+    test_partitions: int = 1
     inferencing_samples: int = MISSING
+    inferencing_partitions: int = 1
     n_features: int = MISSING
     n_informative: Optional[int] = None
 

--- a/src/common/tasks.py
+++ b/src/common/tasks.py
@@ -39,6 +39,7 @@ class data_generation_task:
     inferencing_partitions: int = 1
     n_features: int = MISSING
     n_informative: Optional[int] = None
+    delimiter: str = "comma"
 
 @dataclass
 class training_task:

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -108,6 +108,7 @@ def data_generation_main_pipeline_function(config):
             inferencing_partitions = generation_task.inferencing_partitions,
             n_features = generation_task.n_features,
             n_informative = generation_task.n_informative,
+            delimiter = generation_task.delimiter,
             random_state = 5,
             verbose = False,
             custom_properties = benchmark_custom_properties

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -98,8 +98,11 @@ def data_generation_main_pipeline_function(config):
         generate_data_step = generate_data_component(
             learning_task = generation_task.task,
             train_samples = generation_task.train_samples,
+            train_partitions = generation_task.train_partitions,
             test_samples = generation_task.test_samples,
+            test_partitions = generation_task.test_partitions,
             inferencing_samples = generation_task.inferencing_samples,
+            inferencing_partitions = generation_task.inferencing_partitions,
             n_features = generation_task.n_features,
             n_informative = generation_task.n_informative,
             random_state = 5,

--- a/src/scripts/data_processing/generate_data/generate.py
+++ b/src/scripts/data_processing/generate_data/generate.py
@@ -69,6 +69,11 @@ class GenerateSyntheticDataScript(RunnableScript):
         group_params.add_argument("--n_redundant", required=False, type=int)
         group_params.add_argument("--random_state", required=False, default=None, type=int)
 
+        group_params = parser.add_argument_group("Format params")
+        group_params.add_argument(
+            "--delimiter", required=False, type=str, choices=['tab', 'comma', 'space'], default='comma'
+        )
+
         group_o = parser.add_argument_group("Outputs")
         group_o.add_argument(
             "--output_train",
@@ -125,21 +130,21 @@ class GenerateSyntheticDataScript(RunnableScript):
         numpy.savetxt(
             os.path.join(args.output_train, "train_0.txt"),
             train_data,
-            delimiter=",",
+            delimiter=args.delimiter,
             newline="\n",
             fmt="%1.3f",
         )
         numpy.savetxt(
             os.path.join(args.output_test, "test_0.txt"),
             test_data,
-            delimiter=",",
+            delimiter=args.delimiter,
             newline="\n",
             fmt="%1.3f",
         )
         numpy.savetxt(
             os.path.join(args.output_inference, "inference_0.txt"),
             inference_data,
-            delimiter=",",
+            delimiter=args.delimiter,
             newline="\n",
             fmt="%1.3f",
         )
@@ -213,7 +218,7 @@ class GenerateSyntheticDataScript(RunnableScript):
                         numpy.savetxt(
                             output_file,
                             data,
-                            delimiter=",",
+                            delimiter=args.delimiter,
                             newline="\n",
                             fmt="%1.3f",
                         )
@@ -239,6 +244,14 @@ class GenerateSyntheticDataScript(RunnableScript):
         os.makedirs(args.output_train, exist_ok=True)
         os.makedirs(args.output_test, exist_ok=True)
         os.makedirs(args.output_inference, exist_ok=True)
+
+        # transform delimiter
+        if args.delimiter == "comma":
+            args.delimiter = ","
+        elif args.delimiter == "tab"
+            args.delimiter = "\t"
+        elif args.delimiter == "space"
+            args.delimiter = " "
 
         metrics_logger.log_parameters(
             type=args.type,

--- a/src/scripts/data_processing/generate_data/generate.py
+++ b/src/scripts/data_processing/generate_data/generate.py
@@ -193,7 +193,7 @@ class GenerateSyntheticDataScript(RunnableScript):
                 (os.path.join(args.output_inference, f"inference_{i}.txt"), generator, inferencing_partition_size//batch_size)
             )
 
-    def execute_tasks(self):
+    def execute_tasks(self, args):
         # show some outputs first
         for output_file_path, generator, batches in self.generation_tasks:
             self.logger.info(f"Will generate output {output_file_path} with {batches} batches")
@@ -270,7 +270,7 @@ class GenerateSyntheticDataScript(RunnableScript):
             self.generate_classification(args)
         elif args.type == "regression":
             self.generate_regression_tasks(args)
-            self.execute_tasks()
+            self.execute_tasks(args)
         else:
             raise NotImplementedError(f"--type {args.type} is not implemented.")
 

--- a/src/scripts/data_processing/generate_data/generate.py
+++ b/src/scripts/data_processing/generate_data/generate.py
@@ -248,9 +248,9 @@ class GenerateSyntheticDataScript(RunnableScript):
         # transform delimiter
         if args.delimiter == "comma":
             args.delimiter = ","
-        elif args.delimiter == "tab"
+        elif args.delimiter == "tab":
             args.delimiter = "\t"
-        elif args.delimiter == "space"
+        elif args.delimiter == "space":
             args.delimiter = " "
 
         metrics_logger.log_parameters(

--- a/src/scripts/data_processing/generate_data/generate.py
+++ b/src/scripts/data_processing/generate_data/generate.py
@@ -174,7 +174,7 @@ class GenerateSyntheticDataScript(RunnableScript):
         inferencing_partition_size = args.inferencing_samples // args.inferencing_partitions
 
         batch_size = min(
-            1000,
+            10000,
             train_partition_size,
             test_partition_size,
             inferencing_partition_size,

--- a/src/scripts/data_processing/generate_data/spec.yaml
+++ b/src/scripts/data_processing/generate_data/spec.yaml
@@ -68,6 +68,14 @@ inputs:
     description: random seed
     optional: true
 
+  delimiter:
+    type: Enum
+    default: "comma"
+    enum:
+      - tab
+      - comma
+      - space
+
   # generic benchmark parameters
   verbose:
     type: Boolean
@@ -99,6 +107,7 @@ command: >-
   --n_informative {inputs.n_informative}
   [--n_redundant {inputs.n_redundant}]
   [--random_state {inputs.random_state}]
+  --delimiter {inputs.delimiter}
   --output_train {outputs.output_train}
   --output_test {outputs.output_test}
   --output_inference {outputs.output_inference}

--- a/src/scripts/data_processing/generate_data/spec.yaml
+++ b/src/scripts/data_processing/generate_data/spec.yaml
@@ -1,9 +1,9 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: generate_synthetic_data
 version: 1.0.5
-display_name: "Generate Synthetic Data (small)"
+display_name: "Generate Synthetic Data"
 type: CommandComponent
-description: "Generate synthetic data using scikit-learn make_* functions"
+description: "Generate data for classification or regression."
 is_deterministic: true
 
 tags:
@@ -24,15 +24,30 @@ inputs:
     description: Number of training samples to generate
     default: 1000
     optional: false
+  train_partitions:
+    type: Integer
+    description: Number of partitions to generate for training data
+    default: 1
+    optional: false
   test_samples:
     type: Integer
     description: Number of testing samples to generate
     default: 100
     optional: false
+  test_partitions:
+    type: Integer
+    description: Number of partitions to generate for testing data
+    default: 1
+    optional: false
   inferencing_samples:
     type: Integer
     description: Number of inferencing samples to generate
     default: 1000
+    optional: false
+  inferencing_partitions:
+    type: Integer
+    description: Number of partitions to generate for inferencing data
+    default: 1
     optional: false
   n_features:
     type: Integer
@@ -75,8 +90,11 @@ command: >-
   python generate.py
   --type {inputs.learning_task}
   --train_samples {inputs.train_samples}
+  --train_partitions {inputs.train_partitions}
   --test_samples {inputs.test_samples}
+  --test_partitions {inputs.test_partitions}
   --inferencing_samples {inputs.inferencing_samples}
+  --inferencing_partitions {inputs.inferencing_partitions}
   --n_features {inputs.n_features}
   --n_informative {inputs.n_informative}
   [--n_redundant {inputs.n_redundant}]

--- a/tests/common/test_data.py
+++ b/tests/common/test_data.py
@@ -1,0 +1,71 @@
+"""Tests src/common/data.py"""
+import os
+import pytest
+from unittest.mock import call, Mock, patch
+
+from common.data import RegressionDataGenerator
+
+def test_regression_data_generator():
+    """Tests format of outputs of RegressionDataGenerator"""
+    generator = RegressionDataGenerator(
+        n_features=100,
+        n_informative=50,
+        n_targets=1,
+        bias=1.0,
+        noise=1.0,
+        seed=4
+    )
+
+    for i in range(10):
+        batch = generator.generate_batch(64)
+
+        assert batch is not None
+        assert isinstance(batch, tuple)
+        assert len(batch) == 2
+
+        X, y = batch
+        assert X is not None
+        assert y is not None
+
+        assert X.shape == (64, 100)
+        assert y.shape == (64,)
+
+def test_regression_data_generator_reproducibility():
+    """Tests initializing generator with seeds"""
+    generator1 = RegressionDataGenerator(
+        n_features=100,
+        n_informative=50,
+        n_targets=1,
+        bias=1.0,
+        noise=1.0,
+        seed=4
+    )
+    X1,y1 = generator1.generate_batch(64)
+
+    generator2 = RegressionDataGenerator(
+        n_features=100,
+        n_informative=50,
+        n_targets=1,
+        bias=1.0,
+        noise=1.0,
+        seed=5
+    )
+    X2,y2 = generator2.generate_batch(64)
+
+    generator3 = RegressionDataGenerator(
+        n_features=100,
+        n_informative=50,
+        n_targets=1,
+        bias=1.0,
+        noise=1.0,
+        seed=4 # <<< Equal to generator 1
+    )
+    X3,y3 = generator3.generate_batch(64)
+
+    # if using same seed twice, should be equal strictly
+    assert (X1 == X3).all()
+    assert (y1 == y3).all()
+
+    # if using different seeds, likely to be different
+    assert (X1 != X2).all()
+    assert (y1 != y2).all()

--- a/tests/common/test_data.py
+++ b/tests/common/test_data.py
@@ -8,6 +8,7 @@ from common.data import RegressionDataGenerator
 def test_regression_data_generator():
     """Tests format of outputs of RegressionDataGenerator"""
     generator = RegressionDataGenerator(
+        batch_size=64,
         n_features=100,
         n_informative=50,
         n_targets=1,
@@ -17,7 +18,7 @@ def test_regression_data_generator():
     )
 
     for i in range(10):
-        batch = generator.generate_batch(64)
+        batch = generator.generate()
 
         assert batch is not None
         assert isinstance(batch, tuple)
@@ -33,6 +34,7 @@ def test_regression_data_generator():
 def test_regression_data_generator_reproducibility():
     """Tests initializing generator with seeds"""
     generator1 = RegressionDataGenerator(
+        batch_size=64,
         n_features=100,
         n_informative=50,
         n_targets=1,
@@ -40,9 +42,10 @@ def test_regression_data_generator_reproducibility():
         noise=1.0,
         seed=4
     )
-    X1,y1 = generator1.generate_batch(64)
+    X1,y1 = generator1.generate()
 
     generator2 = RegressionDataGenerator(
+        batch_size=64,
         n_features=100,
         n_informative=50,
         n_targets=1,
@@ -50,9 +53,10 @@ def test_regression_data_generator_reproducibility():
         noise=1.0,
         seed=5
     )
-    X2,y2 = generator2.generate_batch(64)
+    X2,y2 = generator2.generate()
 
     generator3 = RegressionDataGenerator(
+        batch_size=64,
         n_features=100,
         n_informative=50,
         n_targets=1,
@@ -60,7 +64,7 @@ def test_regression_data_generator_reproducibility():
         noise=1.0,
         seed=4 # <<< Equal to generator 1
     )
-    X3,y3 = generator3.generate_batch(64)
+    X3,y3 = generator3.generate()
 
     # if using same seed twice, should be equal strictly
     assert (X1 == X3).all()

--- a/tests/scripts/test_generate_data.py
+++ b/tests/scripts/test_generate_data.py
@@ -11,29 +11,29 @@ from unittest.mock import patch
 from scripts.data_processing.generate_data import generate
 
 
-@pytest.mark.parametrize("task_type", ["regression", "classification"])
-def test_generate_data(temporary_dir, task_type):
+def test_generate_regression_data(temporary_dir):
     """Tests src/scripts/data_processing/generate_data/generate.py"""
-    output_train = os.path.join(temporary_dir, "train")
-    output_test = os.path.join(temporary_dir, "test")
-    output_inference = os.path.join(temporary_dir, "inference")
+    task_type = "regression"
+    output_train = os.path.join(temporary_dir, task_type, "train")
+    output_test = os.path.join(temporary_dir, task_type, "test")
+    output_inference = os.path.join(temporary_dir, task_type, "inference")
 
     # create test arguments for the script
     script_args = [
         "generate.py",
         "--train_samples", "100",
-        "--train_partitions", "10",
+        "--train_partitions", "4",
         "--test_samples", "10",
         "--test_partitions", "2",
         "--inferencing_samples", "100",
-        "--inferencing_partitions", "5",
+        "--inferencing_partitions", "1",
         "--n_features", "40",
         "--n_informative", "10",
         "--random_state", "5",
         "--output_train", output_train,
         "--output_test", output_test,
         "--output_inference", output_inference,
-        "--type", "regression",
+        "--type", task_type,
     ]
     if task_type == "classification":
         script_args.extend(["--n_redundant", "5"])
@@ -47,8 +47,82 @@ def test_generate_data(temporary_dir, task_type):
         os.path.join(output_train, "train_0.txt")
     ), "Script generate.py should generate train_0.txt under --output dir but did not"
     assert os.path.isfile(
+        os.path.join(output_train, "train_1.txt")
+    ), "Script generate.py should generate train_1.txt under --output dir but did not"
+    assert os.path.isfile(
+        os.path.join(output_train, "train_2.txt")
+    ), "Script generate.py should generate train_2.txt under --output dir but did not"
+    assert os.path.isfile(
+        os.path.join(output_train, "train_3.txt")
+    ), "Script generate.py should generate train_3.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_train, "train_4.txt")
+    ), "Script generate.py should NOT generate train_4.txt under --output dir but DID"
+
+    assert os.path.isfile(
         os.path.join(output_test, "test_0.txt")
     ), "Script generate.py should generate test_0.txt under --output dir but did not"
     assert os.path.isfile(
+        os.path.join(output_test, "test_1.txt")
+    ), "Script generate.py should generate test_1.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_test, "test_2.txt")
+    ), "Script generate.py should NOT generate test_2.txt under --output dir but DID"
+
+    assert os.path.isfile(
         os.path.join(output_inference, "inference_0.txt")
     ), "Script generate.py should generate inference_0.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_inference, "inference_1.txt")
+    ), "Script generate.py should NOT generate inference_1.txt under --output dir but DID"
+
+
+def test_generate_classification_data(temporary_dir):
+    """Tests src/scripts/data_processing/generate_data/generate.py"""
+    task_type = "classification"
+    output_train = os.path.join(temporary_dir, task_type, "train")
+    output_test = os.path.join(temporary_dir, task_type, "test")
+    output_inference = os.path.join(temporary_dir, task_type, "inference")
+
+    # create test arguments for the script
+    script_args = [
+        "generate.py",
+        "--train_samples", "100",
+        "--test_samples", "10",
+        "--inferencing_samples", "100",
+        "--n_features", "40",
+        "--n_informative", "10",
+        "--random_state", "5",
+        "--output_train", output_train,
+        "--output_test", output_test,
+        "--output_inference", output_inference,
+        "--type", task_type,
+    ]
+    if task_type == "classification":
+        script_args.extend(["--n_redundant", "5"])
+
+    # replaces sys.argv with test arguments and run main
+    with patch.object(sys, "argv", script_args):
+        generate.main()
+
+    # test expected outputs
+    assert os.path.isfile(
+        os.path.join(output_train, "train_0.txt")
+    ), "Script generate.py should generate train_0.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_train, "train_1.txt")
+    ), "Script generate.py should NOT generate train_1.txt under --output dir but DID"
+
+    assert os.path.isfile(
+        os.path.join(output_test, "test_0.txt")
+    ), "Script generate.py should generate test_0.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_test, "test_1.txt")
+    ), "Script generate.py should NOT generate test_1.txt under --output dir but DID"
+
+    assert os.path.isfile(
+        os.path.join(output_inference, "inference_0.txt")
+    ), "Script generate.py should generate inference_0.txt under --output dir but did not"
+    assert not os.path.isfile(
+        os.path.join(output_inference, "inference_1.txt")
+    ), "Script generate.py should NOT generate inference_1.txt under --output dir but DID"

--- a/tests/scripts/test_generate_data.py
+++ b/tests/scripts/test_generate_data.py
@@ -22,8 +22,11 @@ def test_generate_data(temporary_dir, task_type):
     script_args = [
         "generate.py",
         "--train_samples", "100",
+        "--train_partitions", "10",
         "--test_samples", "10",
+        "--test_partitions", "2",
         "--inferencing_samples", "100",
+        "--inferencing_partitions", "5",
         "--n_features", "40",
         "--n_informative", "10",
         "--random_state", "5",
@@ -41,11 +44,11 @@ def test_generate_data(temporary_dir, task_type):
 
     # test expected outputs
     assert os.path.isfile(
-        os.path.join(output_train, "train.txt")
-    ), "Script generate.py should generate train.txt under --output dir but did not"
+        os.path.join(output_train, "train_0.txt")
+    ), "Script generate.py should generate train_0.txt under --output dir but did not"
     assert os.path.isfile(
-        os.path.join(output_test, "test.txt")
-    ), "Script generate.py should generate test.txt under --output dir but did not"
+        os.path.join(output_test, "test_0.txt")
+    ), "Script generate.py should generate test_0.txt under --output dir but did not"
     assert os.path.isfile(
-        os.path.join(output_inference, "inference.txt")
-    ), "Script generate.py should generate inference.txt under --output dir but did not"
+        os.path.join(output_inference, "inference_0.txt")
+    ), "Script generate.py should generate inference_0.txt under --output dir but did not"


### PR DESCRIPTION
This implements a synthetic data generator not constrained by the memory limit (but still constrained by disk).

This works by creating a synthetic data generator that can produce batches of random data. This generator is being iterated on to create the required amount of data for training, testing and inferencing and append all batched sequentially.

This is still limited by disk allocation for now.