### PR TITLE
Upgrade to latest shrike+azuremlsdk, add tags to datasets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pytest-cov==2.12.1
 pytest-mock==3.6.1
 mlflow==1.21.0
 shrike[pipeline]==1.14.7
-azure-ml-component==0.9.4.post1
+azure-ml-component==0.9.4.post1  # for component dsl
+azureml-train-core==1.36.0  # for azureml.train.hyperdrive
 hydra-core~=1.0.3
 omegaconf~=2.1
 treelite==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ mlflow==1.21.0
 shrike[pipeline]==1.14.7
 azure-ml-component==0.9.4.post1  # for component dsl
 azureml-train-core==1.36.0  # for azureml.train.hyperdrive
+azureml-dataset-runtime==1.36.0  # to register dataset
 hydra-core~=1.0.3
 omegaconf~=2.1
 treelite==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ pytest==6.2.4
 pytest-cov==2.12.1
 pytest-mock==3.6.1
 mlflow==1.21.0
-shrike[pipeline]==1.11.10
-hydra-core==1.0.7
-omegaconf==2.0.6
+shrike[pipeline]==1.14.7
+azure-ml-component==0.9.4.post1
+hydra-core~=1.0.3
+omegaconf~=2.1
 treelite==2.1.0
 treelite_runtime==2.1.0
 mpi4py==3.1.1

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -94,7 +94,10 @@ def data_generation_main_pipeline_function(config):
         'benchmark_name' : config.data_generation_config.benchmark_name
     })
 
+    # for each task provided in the general config
     for generation_task in config.data_generation_config.tasks:
+
+        # run a generation step with the right parameters
         generate_data_step = generate_data_component(
             learning_task = generation_task.task,
             train_samples = generation_task.train_samples,
@@ -106,19 +109,23 @@ def data_generation_main_pipeline_function(config):
             verbose = False,
             custom_properties = benchmark_custom_properties
         )
+        # run it on the right compute target
         generate_data_step.runsettings.configure(target=config.compute.linux_cpu)
 
+        # if config asks to register the outputs automatically...
         if config.data_generation_config.register_outputs:
+            # create a prefix for the dataset
             dataset_prefix = "{prefix}-{task}-{cols}cols".format(
                 prefix=config.data_generation_config.register_outputs_prefix,
                 task=generation_task.task,
                 cols=generation_task.n_features
             )
             
+            # register each output (train, test, inference)
             generate_data_step.outputs.output_train.register_as(
                 name=f"{dataset_prefix}-{generation_task.train_samples}samples-train",
                 create_new_version=True,
-                tags={
+                tags={ # add tags that will show up in AzureML
                     'type':'train',
                     'task':generation_task.task,
                     'origin':'synthetic',
@@ -130,7 +137,7 @@ def data_generation_main_pipeline_function(config):
             generate_data_step.outputs.output_test.register_as(
                 name=f"{dataset_prefix}-{generation_task.test_samples}samples-test",
                 create_new_version=True,
-                tags={
+                tags={ # add tags that will show up in AzureML
                     'type':'test',
                     'task':generation_task.task,
                     'origin':'synthetic',
@@ -142,7 +149,7 @@ def data_generation_main_pipeline_function(config):
             generate_data_step.outputs.output_inference.register_as(
                 name=f"{dataset_prefix}-{generation_task.inferencing_samples}samples-inference",
                 create_new_version=True,
-                tags={
+                tags={ # add tags that will show up in AzureML
                     'type':'inference',
                     'task':generation_task.task,
                     'origin':'synthetic',

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -119,9 +119,9 @@ def data_generation_main_pipeline_function(config):
                 name=f"{dataset_prefix}-{generation_task.train_samples}samples-train",
                 create_new_version=True,
                 tags={
-                    'phase':'train',
+                    'type':'train',
                     'task':generation_task.task,
-                    'type':'synthetic',
+                    'origin':'synthetic',
                     'samples':generation_task.train_samples,
                     'features':generation_task.n_features,
                     'informative':generation_task.n_informative
@@ -131,9 +131,9 @@ def data_generation_main_pipeline_function(config):
                 name=f"{dataset_prefix}-{generation_task.test_samples}samples-test",
                 create_new_version=True,
                 tags={
-                    'phase':'test',
+                    'type':'test',
                     'task':generation_task.task,
-                    'type':'synthetic',
+                    'origin':'synthetic',
                     'samples':generation_task.test_samples,
                     'features':generation_task.n_features,
                     'informative':generation_task.n_informative
@@ -143,9 +143,9 @@ def data_generation_main_pipeline_function(config):
                 name=f"{dataset_prefix}-{generation_task.inferencing_samples}samples-inference",
                 create_new_version=True,
                 tags={
-                    'phase':'inference',
+                    'type':'inference',
                     'task':generation_task.task,
-                    'type':'synthetic',
+                    'origin':'synthetic',
                     'samples':generation_task.inferencing_samples,
                     'features':generation_task.n_features,
                     'informative':generation_task.n_informative

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -115,17 +115,41 @@ def data_generation_main_pipeline_function(config):
                 cols=generation_task.n_features
             )
             
-            generate_data_step.outputs.train.register_as(
+            generate_data_step.outputs.output_train.register_as(
                 name=f"{dataset_prefix}-{generation_task.train_samples}samples-train",
-                create_new_version=True
-            )  
-            generate_data_step.outputs.test.register_as(
+                create_new_version=True,
+                tags={
+                    'phase':'train',
+                    'task':generation_task.task,
+                    'type':'synthetic',
+                    'samples':generation_task.train_samples,
+                    'features':generation_task.n_features,
+                    'informative':generation_task.n_informative
+                }
+            )
+            generate_data_step.outputs.output_test.register_as(
                 name=f"{dataset_prefix}-{generation_task.test_samples}samples-test",
-                create_new_version=True
-            )  
-            generate_data_step.outputs.inference.register_as(
+                create_new_version=True,
+                tags={
+                    'phase':'test',
+                    'task':generation_task.task,
+                    'type':'synthetic',
+                    'samples':generation_task.test_samples,
+                    'features':generation_task.n_features,
+                    'informative':generation_task.n_informative
+                }
+            )
+            generate_data_step.outputs.output_inference.register_as(
                 name=f"{dataset_prefix}-{generation_task.inferencing_samples}samples-inference",
-                create_new_version=True
+                create_new_version=True,
+                tags={
+                    'phase':'inference',
+                    'task':generation_task.task,
+                    'type':'synthetic',
+                    'samples':generation_task.inferencing_samples,
+                    'features':generation_task.n_features,
+                    'informative':generation_task.n_informative
+                }
             )  
 
 


### PR DESCRIPTION
This PR just upgrades requirements to use latest shrike and azure-ml-component sdks.

hydra-core has been downgraded to match with shrike requirements.

We're also adding tags to generated datasets, as a new feature of component sdk.