### PR TITLE
Add url after submit, and show warning to add +run.submit=true

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -159,6 +159,12 @@ class RunnableScript():
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
+        # show the command used to run
+        if cli_args:
+            logger.info(f"Running main() with specific cli args: {cli_args}")
+        else:
+            logger.info(f"Running main() with sys.argv={sys.argv}")
+
         # construct arg parser
         parser = cls.get_arg_parser()
     

--- a/src/common/pipelines.py
+++ b/src/common/pipelines.py
@@ -171,7 +171,7 @@ def pipeline_submit(workspace: Workspace,
         experiment_description = experiment_description[:5000-50] + "\n<<<TRUNCATED DUE TO SIZE LIMIT>>>"
 
     if pipeline_config.run.submit:
-        return pipeline_instance.submit(
+        pipeline_run = pipeline_instance.submit(
             workspace=workspace,
             experiment_name=(experiment_name or pipeline_config.experiment.name),
             description=experiment_description,
@@ -181,3 +181,21 @@ def pipeline_submit(workspace: Workspace,
             regenerate_outputs=pipeline_config.run.regenerate_outputs,
             continue_on_step_failure=pipeline_config.run.continue_on_failure,
         )
+
+        logging.info(
+            f"""
+#################################
+#################################
+#################################
+
+Follow link below to access your pipeline run directly:
+-------------------------------------------------------
+{pipeline_run.get_portal_url()}
+
+#################################
+#################################
+#################################
+        """
+        )
+    else:
+        logging.warning("Pipeline was not submitted, to submit it please add +run.submit=true to your command.")

--- a/src/common/pipelines.py
+++ b/src/common/pipelines.py
@@ -197,5 +197,7 @@ Follow link below to access your pipeline run directly:
 #################################
         """
         )
+
+        return pipeline_run
     else:
         logging.warning("Pipeline was not submitted, to submit it please add +run.submit=true to your command.")


### PR DESCRIPTION
To make submission more user friendly, this PR adds a warning that pipeline is not submitted by default. It also, shows the portal url clearly in the logs.