### PR TITLE
Add readable "display name" for each step

### DIFF
--- a/src/common/aml.py
+++ b/src/common/aml.py
@@ -6,6 +6,7 @@ This script contains methods to handle connection to AzureML,
 such as registering Datasets or obtaining a Dataset handler from a given workspace.
 """
 import logging
+import re
 from azureml.core import Datastore, Dataset
 
 
@@ -66,6 +67,7 @@ def load_dataset_from_data_input_spec(workspace, data_input_spec):
 
     return loaded_dataset
 
+
 def apply_sweep_settings(step, sweep_settings_config):
     """Applies the settings to a sweep step based on a config dataclass.
 
@@ -120,3 +122,27 @@ def apply_sweep_settings(step, sweep_settings_config):
             pass
         else:
             raise NotImplementedError(f"sweep settings early_termination policy_type={sweep_settings_config.early_termination.policy_type} is not implemented.")
+
+
+def format_run_name(run_name: str):
+    """Formats a run name to fit with AzureML constraints.
+    
+    Args:
+        run_name (str): string to be formatted.
+
+    Returns:
+        formatted_run_name (str)
+    
+    Notes:
+        Node name must start with a letter,
+        and can only contain letters, numbers,
+        underscores, within 1-255 characters.
+    """
+    # removing all chars not allowed, use underscore instead
+    formatted_run_name = re.sub(r'[^a-zA-Z0-9_]', '_', run_name)
+
+    # cutting to first 255 chars
+    if len(formatted_run_name) > 255:
+        formatted_run_name = formatted_run_name[0:255]
+
+    return formatted_run_name

--- a/src/pipelines/azureml/data_generation.py
+++ b/src/pipelines/azureml/data_generation.py
@@ -38,6 +38,8 @@ from common.pipelines import (
     pipeline_submit,
     COMPONENTS_ROOT
 )
+from common.aml import format_run_name
+
 
 ### CONFIG DATACLASS ###
 
@@ -117,6 +119,15 @@ def data_generation_main_pipeline_function(config):
         )
         # run it on the right compute target
         generate_data_step.runsettings.configure(target=config.compute.linux_cpu)
+
+        # generate a readable run name
+        generate_data_step.node_name = format_run_name("generate_{}_train{}test{}inf{}_feat{}".format(
+            generation_task.task,
+            generation_task.train_samples,
+            generation_task.test_samples,
+            generation_task.inferencing_samples,
+            generation_task.n_features
+        ))
 
         # if config asks to register the outputs automatically...
         if config.data_generation_config.register_outputs:

--- a/src/pipelines/azureml/lightgbm_inferencing.py
+++ b/src/pipelines/azureml/lightgbm_inferencing.py
@@ -39,7 +39,7 @@ from common.pipelines import (
     pipeline_submit,
     COMPONENTS_ROOT
 )
-from common.aml import load_dataset_from_data_input_spec
+from common.aml import load_dataset_from_data_input_spec, format_run_name
 
 ### CONFIG DATACLASS ###
 
@@ -193,6 +193,9 @@ def inferencing_task_pipeline_function(benchmark_custom_properties,
         # add some comment to the component
         inferencing_step.comment = " -- ".join(variant_comment)
 
+        # provide step readable display name
+        inferencing_step.node_name = format_run_name(f"inferencing_{variant.framework}_{variant_index}")
+
     # return {key: output}'
     return pipeline_outputs
 
@@ -213,7 +216,7 @@ def inferencing_all_tasks(workspace, config):
     Returns:
         None
     """
-    for inferencing_task in config.lightgbm_inferencing_config.tasks:
+    for task_index, inferencing_task in enumerate(config.lightgbm_inferencing_config.tasks):
         data = load_dataset_from_data_input_spec(workspace, inferencing_task.data)
         model = load_dataset_from_data_input_spec(workspace, inferencing_task.model)
 
@@ -237,6 +240,9 @@ def inferencing_all_tasks(workspace, config):
             f"benchmark name: {config.lightgbm_inferencing_config.benchmark_name}",
             # NOTE: add more here?
         ])
+
+        # provide readable subgraph display name
+        inferencing_task_subgraph_step.node_name = f"inferencing_task_{task_index}"
 
 
 ### MAIN BLOCK ###

--- a/src/pipelines/azureml/lightgbm_training.py
+++ b/src/pipelines/azureml/lightgbm_training.py
@@ -317,7 +317,7 @@ def lightgbm_training_pipeline_function(config,
         )
 
         # provide step readable display name
-        lightgbm_train_step.node_name = format_run_name(f"training_{variant.framework}_{variant_index}")
+        lightgbm_train_step.node_name = format_run_name(f"training_{variant_params.framework}_{variant_index}")
 
         # optional: save output model
         if variant_params.output and variant_params.output.register_model:

--- a/src/pipelines/azureml/lightgbm_training.py
+++ b/src/pipelines/azureml/lightgbm_training.py
@@ -34,6 +34,7 @@ from common.tasks import training_task, training_variant
 from common.sweep import SweepParameterParser
 from common.aml import load_dataset_from_data_input_spec
 from common.aml import apply_sweep_settings
+from common.aml import format_run_name
 from common.pipelines import (
     parse_pipeline_config,
     azureml_connect,
@@ -313,6 +314,9 @@ def lightgbm_training_pipeline_function(config,
                 # add more
             ]
         )
+
+        # provide step readable display name
+        lightgbm_train_step.node_name = format_run_name(f"training_{variant.framework}_{variant_index}")
 
         # optional: save output model
         if variant_params.output and variant_params.output.register_model:

--- a/tests/common/test_aml.py
+++ b/tests/common/test_aml.py
@@ -1,0 +1,36 @@
+"""Tests src/common/aml.py"""
+import os
+import pytest
+from unittest.mock import call, Mock, patch
+import time
+import json
+
+from common.aml import apply_sweep_settings
+from common.aml import format_run_name
+from common.aml import load_dataset_from_data_input_spec
+from common.aml import dataset_from_dstore_path
+
+
+def test_format_run_name():
+    """ Tests format_run_name() """
+    test_cases = [
+        {
+            'input':   "run name foo",
+            'expected':"run_name_foo"
+        },
+        {
+            'input':   "abcd01234",
+            'expected':"abcd01234"
+        },
+        {
+            'input':   "gen 1000samples+3train*foo",
+            'expected':"gen_1000samples_3train_foo"
+        },
+        {
+            'input': "a"*1000,
+            'expected': "a"*255
+        }
+    ]
+
+    for test_case in test_cases:
+        assert format_run_name(test_case['input']) == test_case['expected']


### PR DESCRIPTION
This PR uses component sdk to enforce a readable display name for all the runs for training and inferencing.

This code will add a programmatically generated `node_name` for the steps of our pipelines. This node name is filtered out to avoid breaking naming conventions in AzureML (`filter_run_name` method).