### PR TITLE
Implement log_artifact methods in metrics logger

### DIFF
--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -98,6 +98,30 @@ class MetricsLogger():
         except mlflow.exceptions.MlflowException:
             self._logger.critical(f"Could not log figure using MLFLOW due to exception:\n{traceback.format_exc()}")
 
+    def log_artifact(self, local_path, artifact_path=None):
+        """Logs an artifact
+        
+        Args:
+            local_path (str): Path to the file to write.
+            artifact_path (str): If provided, the directory in artifact_uri to write to.
+        """
+        try:
+            mlflow.log_artifact(local_path, artifact_path=artifact_path)
+        except mlflow.exceptions.MlflowException:
+            self._logger.critical(f"Could not log artifact using MLFLOW due to exception:\n{traceback.format_exc()}")
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        """Logs an artifact
+        
+        Args:
+            local_dir (str): Path to the directory of files to write.
+            artifact_path (str): If provided, the directory in artifact_uri to write to.
+        """
+        try:
+            mlflow.log_artifacts(local_dir, artifact_path=artifact_path)
+        except mlflow.exceptions.MlflowException:
+            self._logger.critical(f"Could not log artifacts using MLFLOW due to exception:\n{traceback.format_exc()}")
+
     def set_properties(self, **kwargs):
         """Set properties/tags for the session.
         

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -138,6 +138,46 @@ def test_metrics_logger_log_metric_non_allowed_chars():
         assert MetricsLogger._remove_non_allowed_chars(test_case['input']) == test_case['expected']
 
 
+@patch('mlflow.log_artifact')
+def test_metrics_logger_log_artifact(mlflow_log_artifact_mock, temporary_dir):
+    """ Tests MetricsLogger().log_artifact() """
+    # create a sample artifact file
+    artifact_path = os.path.join(temporary_dir, "mock_artifact.ext")
+    with open(artifact_path, "w") as o_file:
+        o_file.write("foo\n")
+
+    metrics_logger = MetricsLogger()
+    metrics_logger.open()
+    metrics_logger.log_artifact(artifact_path, artifact_path="foo/")
+    metrics_logger.close()
+
+    mlflow_log_artifact_mock.assert_called_with(
+        artifact_path,
+        artifact_path="foo/"
+    )
+
+
+@patch('mlflow.log_artifacts')
+def test_metrics_logger_log_artifacts(mlflow_log_artifacts_mock, temporary_dir):
+    """ Tests MetricsLogger().log_artifact() """
+    # create a sample artifact folder
+    artifact_dir = os.path.join(temporary_dir, "artifacts", "mock_artifact.ext")
+    os.makedirs(artifact_dir, exist_ok=True)
+
+    with open(os.path.join(artifact_dir, "test.ext"), "w") as o_file:
+        o_file.write("bar\n")
+
+    metrics_logger = MetricsLogger()
+    metrics_logger.open()
+    metrics_logger.log_artifacts(artifact_dir, artifact_path="bar/")
+    metrics_logger.close()
+
+    mlflow_log_artifacts_mock.assert_called_with(
+        artifact_dir,
+        artifact_path="bar/"
+    )
+
+
 @patch('mlflow.set_tags')
 def test_metrics_logger_set_properties(mlflow_set_tags_mock):
     """ Tests MetricsLogger().set_properties() """


### PR DESCRIPTION
These methods will let us record files (in particular, ray timeline, or models) in the mlflow session.