### PR TITLE
Add force param to azureml_connect call to allow for tenant switch

### DIFF
--- a/src/common/pipelines.py
+++ b/src/common/pipelines.py
@@ -139,7 +139,8 @@ def azureml_connect(config: DictConfig):
         aml_resource_group=config.aml.resource_group,
         aml_workspace_name=config.aml.workspace_name,
         aml_auth=config.aml.auth,
-        aml_tenant=config.aml.tenant
+        aml_tenant=config.aml.tenant,
+        aml_force=config.aml.force
     )
 
 def pipeline_submit(workspace: Workspace,


### PR DESCRIPTION
In the call to `azureml_connect()`, I forgot to add `force` as a parameter. This is important as it allows to switch between tenants more easily (set `aml.force:True` to force tenant re-auth).