### PR TITLE
Add perf reporting to RayScript class

### DIFF
--- a/src/common/ray.py
+++ b/src/common/ray.py
@@ -16,6 +16,8 @@ import subprocess
 import ray
 import time
 
+from .perf import PerformanceMetricsCollector, PerfReportPlotter
+
 class RayScript(RunnableScript):
     def __init__(self, task, framework, framework_version, metrics_prefix=None):
         """ Generic initialization for all script classes.
@@ -40,6 +42,7 @@ class RayScript(RunnableScript):
         self.head_address = None
         self.head_port = 6379
         self.redis_password = None
+        self.available_nodes = 1
 
     @classmethod
     def get_arg_parser(cls, parser=None):
@@ -146,6 +149,26 @@ class RayScript(RunnableScript):
         # open mlflow
         self.metrics_logger.open()
 
+        if self.self_is_head:
+            # record properties only from the main node
+            self.metrics_logger.set_properties(
+                task = self.task,
+                framework = self.framework,
+                framework_version = self.framework_version
+            )
+
+            # if provided some custom_properties by the outside orchestrator
+            if args.custom_properties:
+                self.metrics_logger.set_properties_from_json(args.custom_properties)
+
+            # add properties about environment of this script
+            self.metrics_logger.set_platform_properties()
+
+            # enable perf reporting
+            self.perf_report_collector = PerformanceMetricsCollector()
+            self.perf_report_collector.start()
+
+
     def finalize_run(self, args):
         """Finalize the run, close what needs to be"""
         self.logger.info(f"Finalizing Ray component script...")
@@ -154,6 +177,12 @@ class RayScript(RunnableScript):
         if self.self_is_head:
             self.logger.info(f"At finalization, number of nodes is [nodes={len(ray.nodes())}]")
             ray.shutdown()
+
+        if self.perf_report_collector:
+            self.perf_report_collector.finalize()
+            plotter = PerfReportPlotter(self.metrics_logger)
+            plotter.add_perf_reports(self.perf_report_collector.perf_reports, node=0)
+            plotter.report_nodes_perf()
 
         # close mlflow
         self.metrics_logger.close()


### PR DESCRIPTION
This PR adds fixes to the RayScript class used to run ray components (lightgbm ray inferencing + coming soon lightgbm ray training).

This also adds all the required parameters/properties that were not initially implemented in this class, and that are required for the benchmark analysis script to run.

Finally, it fixes `available_nodes` in RayScript, which wasn't initialized properly, and was failing when running component in distributed mode.

NOTE: this PR was extracted out of the general lightgbm-ray pr #223 .