### PR TITLE
HotFix: specify pip version that works for our build

### DIFF
--- a/.github/workflows/azureml_pipelines.yml
+++ b/.github/workflows/azureml_pipelines.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.1
         pip install flake8==3.9.1 pytest~=6.2 pytest-cov~=2.11
         sudo apt-get install libopenmpi-dev
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/benchmark_scripts.yml
+++ b/.github/workflows/benchmark_scripts.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install libopenmpi-dev
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip==21.3.1
         pip install flake8==3.9.1 pytest~=6.2 pytest-cov~=2.11
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         # hotfix for azurecli issue


### PR DESCRIPTION
Our build currently fails for some dependencies issues. This has happened only after upgrading to latest pip==22.0, this PR fixes the version that was working before.