### PR TITLE
Implement classic AzureML log reporting class (as backup)

### DIFF
--- a/src/common/components.py
+++ b/src/common/components.py
@@ -178,7 +178,7 @@ class RunnableScript():
         logger = logging.getLogger()
         logger.setLevel(logging.INFO)
         console_handler = logging.StreamHandler()
-        formatter = logging.Formatter('SystemLog: %(asctime)s : %(levelname)s : %(name)s : %(message)s')
+        formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(name)s : %(message)s')
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 

--- a/src/common/components.py
+++ b/src/common/components.py
@@ -204,7 +204,7 @@ class RunnableScript():
             # run the actual thing
             script_instance.run(args, script_instance.logger, script_instance.metrics_logger, unknown_args)
         except BaseException as e:
-            logging.critical(f"Exception occured during run():\n{traceback.format_exc()}".replace('\n','--'))
+            logging.critical(f"Exception occured during run():\n{traceback.format_exc()}")
             script_instance.finalize_run(args)
             raise e
 

--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -11,6 +11,7 @@ from .components import RunnableScript
 from dataclasses import dataclass
 from typing import Optional
 
+from .metrics import MLFlowMetricsLogger, AzureMLRunMetricsLogger
 from .perf import PerformanceMetricsCollector, PerfReportPlotter
 
 @dataclass
@@ -203,6 +204,21 @@ class MultiNodeScript(RunnableScript):
     def initialize_run(self, args):
         """Initialize the component run, opens/setups what needs to be"""
         self.logger.info("Initializing multi node component script...")
+
+        # initializes reporting of metrics
+        if args.metrics_driver == 'mlflow':
+            self.metrics_logger = MLFlowMetricsLogger(
+                f"{self.framework}.{self.task}",
+                metrics_prefix=self.metrics_prefix
+            )
+        elif args.metrics_driver == 'azureml':
+            self.metrics_logger = AzureMLRunMetricsLogger(
+                f"{self.framework}.{self.task}",
+                metrics_prefix=self.metrics_prefix
+            )
+        else:
+            # use default metrics_logger (stdout print)
+            pass
 
         if args.multinode_driver == 'socket':
             self.multinode_driver = MultiNodeSocketDriver(machines=args.multinode_machines, listen_port=args.multinode_listen_port)

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -371,7 +371,7 @@ class AzureMLRunMetricsLogger(MetricsLogger):
             pass # for now, do not process those
         else:
             if self._aml_run:
-                self._aml_run.log_metrics(key, key=value, step=step)
+                self._aml_run.log_row(key, key=value, step=step)
 
     def set_properties(self, **kwargs):
         """Set properties/tags for the session.


### PR DESCRIPTION
For prod environment where mlflow would not work due to compliance requirements, AzureML Run log methods could still be applied.

This PR re-implements the `MetricsLogger` class to use AzureML Run instead of MLFlow, with a parameter switch to instantiate the right "driver".