### PR TITLE
[Fix] align name of internal _comm variable in MultiNodeMPIDriver

### DIFF
--- a/src/common/distributed.py
+++ b/src/common/distributed.py
@@ -116,7 +116,7 @@ class MultiNodeMPIDriver(MultiNodeDriver):
                 (world_size > 1), # mpi_available
                 (world_rank == 0), # main_node
             )
-            self.comm = None
+            self._comm = None
         else:
             # init mpi and use comm to detect mpi config
             self.logger.info(f"Running MPI.Init_thread(required={self._mpi_init_mode})")
@@ -125,13 +125,13 @@ class MultiNodeMPIDriver(MultiNodeDriver):
             except self._mpi_module.Exception:
                 self.logger.warning(f"Exception occured during MPI initialization:\n{traceback.format_exc()}")
 
-            self.comm = self._mpi_module.COMM_WORLD
+            self._comm = self._mpi_module.COMM_WORLD
             try:
                 self._multinode_config = multinode_config_class(
-                    self.comm.Get_size(), # world_size
-                    self.comm.Get_rank(), # world_rank
-                    (self.comm.Get_size() > 1), # mpi_available
-                    (self.comm.Get_rank() == 0), # main_node
+                    self._comm.Get_size(), # world_size
+                    self._comm.Get_rank(), # world_rank
+                    (self._comm.Get_size() > 1), # mpi_available
+                    (self._comm.Get_rank() == 0), # main_node
                 )
                 self.logger.info(f"MPI detection results: {self._multinode_config}")
             except:


### PR DESCRIPTION
The member variable `._comm` in MultiNodeMPIDriver wasn't initialized properly in initialize() method. This was overlooked at this is not used anywhere else in the code.

This is fixed in this PR.