### PR TITLE
Pin dependency to fix doc build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ flaml==0.9.6
 # pipelines
 shrike[pipeline]==1.14.7
 azure-ml-component==0.9.4.post1  # for component dsl
+jinja2==3.0.3 #for docs
 azureml-train-core==1.36.0  # for azureml.train.hyperdrive
 azureml-dataset-runtime==1.36.0  # to register dataset
 hydra-core~=1.0.3


### PR DESCRIPTION
As per the [latest doc build](https://github.com/microsoft/lightgbm-benchmark/runs/6220846588?check_suite_focus=true), 
`mkdocstrings 0.15.0 requires Jinja2<3.0,>=2.11, but you have jinja2 3.1.2 which is incompatible.`

`azure-ml-component` has a dependency on `jinja2` but it doesn't pin it to any particular version and the latest version is installed. 