### PR TITLE
Fix CI by pinning protobuf

### DIFF
--- a/.github/workflows/benchmark_scripts.yml
+++ b/.github/workflows/benchmark_scripts.yml
@@ -47,6 +47,8 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         # hotfix for azurecli issue
         pip install --upgrade --force-reinstall --no-cache-dir "azure-cli<2.30.0"
+        # Fix: force protobuf downgrade to avoid exception
+        pip install protobuf==3.19.4
 
     - name: azure login
       uses: azure/login@v1


### PR DESCRIPTION
Fix CI by pinning protobuf version to `3.19.4`

Affected PR: https://github.com/microsoft/lightgbm-benchmark/pull/265111